### PR TITLE
feat: mover com WASD no hello-town

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Integração **tmxlite** via `pkg-config` (`PkgConfig::TMXLITE`).
 - Integração **Lua** via `find_package(Lua)` (include/libs do FindLua nativo).
 - Saída dos binários para `build/bin/<Config>`.
-- 
+- `src/main.cpp`: movimento do “herói” controlado por teclas **W/A/S/D**.
+
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).
 - Erro “Unsupported SFML component: system” (mudança para sintaxe do SFML 3).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,6 @@
 #include <tmxlite/Map.hpp>
 #include <filesystem>
 #include <iostream>
-#include <cmath>
 
 int main() {
     std::cout << "Lumy: hello-town iniciando...\n";
@@ -47,7 +46,7 @@ int main() {
     hero.setOrigin(sf::Vector2f{32.f, 32.f});                    // Vector2f
     hero.setPosition(sf::Vector2f{W * 0.5f, H * 0.5f});          // Vector2f
 
-    sf::Clock clock;
+    const float moveStep = 4.f;
 
     while (window.isOpen()) {
         // pollEvent() retorna std::optional<Event>
@@ -60,9 +59,12 @@ int main() {
             }
         }
 
-        // Movimento bobo só pra ver algo na tela
-        float t = clock.getElapsedTime().asSeconds();
-        hero.setPosition(sf::Vector2f{W * 0.5f + std::sin(t) * 40.f, H * 0.5f});
+        sf::Vector2f pos = hero.getPosition();
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::W)) pos.y -= moveStep;
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::S)) pos.y += moveStep;
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::A)) pos.x -= moveStep;
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::D)) pos.x += moveStep;
+        hero.setPosition(pos);
 
         window.clear(sf::Color::Black);
         window.draw(hero);


### PR DESCRIPTION
## Summary
- replace sinusoidal placeholder movement with W/A/S/D input
- document new hero movement in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a880ad6b7c8327ac415720b98826d9