### PR TITLE
feat(runtime): log TMX map info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Integração **Lua** via `find_package(Lua)` (include/libs do FindLua nativo).
 - Saída dos binários para `build/bin/<Config>`.
 - `src/main.cpp`: movimento do “herói” controlado por teclas **W/A/S/D**.
+- `src/main.cpp`: logs de dimensões e camadas após carregar TMX.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,15 @@ int main() {
             tmx::Map map;
             if (map.load(tmxPath)) {
                 std::cout << "TMX carregado: " << tmxPath << "\n";
+
+                const auto tileCount = map.getTileCount();
+                std::cout << "Dimensões do mapa: " << tileCount.x << " x " << tileCount.y << " tiles\n";
+
+                const auto& layers = map.getLayers();
+                std::cout << "Camadas (" << layers.size() << "):\n";
+                for (const auto& layer : layers) {
+                    std::cout << " - " << layer->getName() << "\n";
+                }
             } else {
                 std::cout << "Falha ao carregar TMX: " << tmxPath << "\n";
             }


### PR DESCRIPTION
## Summary
- log TMX map dimensions and layers after loading

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion)*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a882be69a0832794ff7ecdc15aa4c5