### PR TITLE
test: add basic startup test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `.gitignore` para CMake/VSCode/VS/vcpkg.
 - Regra de **cópia de assets** do `examples/hello-town/` para `bin/<Config>/game/`.
 - Mapa `first.tmx` e tileset simples em `examples/hello-town`.
+- Teste básico de inicialização com GoogleTest.
 
 - 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,13 @@ if(EXISTS "${EXAMPLES_DIR}")
   )
 endif()
 
+# ===== Tests =====
+enable_testing()
+find_package(GTest CONFIG REQUIRED)
+add_executable(lumy-tests tests/basic_startup.cpp)
+target_link_libraries(lumy-tests PRIVATE GTest::gtest_main SFML::Graphics)
+add_test(NAME basic_startup COMMAND lumy-tests)
+
 # ===== Instalação opcional =====
 include(GNUInstallDirs)
 install(TARGETS hello-town RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tests/basic_startup.cpp
+++ b/tests/basic_startup.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+#include <SFML/Graphics.hpp>
+
+TEST(BasicStartup, CanCreateWindow) {
+    sf::RenderWindow window(sf::VideoMode(100, 100), "Test");
+    EXPECT_TRUE(window.isOpen());
+    window.close();
+}


### PR DESCRIPTION
## Summary
- add GoogleTest-based startup test
- wire lumy-tests target into CMake
- note tests in changelog

## Testing
- `ctest --preset msvc-tests` *(fails: Invalid macro expansion in "msvc-vcpkg")*


------
https://chatgpt.com/codex/tasks/task_e_68a8c63d8fe0832784b8e5216cbc2b11