### PR TITLE
feat(runtime): measure frame time with sf::Clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Mapa `first.tmx` e tileset simples em `examples/hello-town`.
 - Teste básico de inicialização com GoogleTest.
 
-- 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).
 - Integração **tmxlite** via `pkg-config` (`PkgConfig::TMXLITE`).
@@ -22,12 +21,12 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Saída dos binários para `build/bin/<Config>`.
 - `src/main.cpp`: movimento do “herói” controlado por teclas **W/A/S/D**.
 - `src/main.cpp`: logs de dimensões e camadas após carregar TMX.
+- `src/main.cpp`: mede tempo entre frames com `sf::Clock`.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).
 - Erro “Unsupported SFML component: system” (mudança para sintaxe do SFML 3).
 - Erro ao configurar por falta de `src/main.cpp`.
-- 
 ### Docs
 - Adicionado `VISION.md`.
 - Adicionado `ROADMAP.md`.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,9 @@ int main() {
     const unsigned W = 640, H = 360;
     sf::RenderWindow window(sf::VideoMode(sf::Vector2u{W, H}), "Lumy — hello-town");
     window.setFramerateLimit(60);
-    
+
+    // Clock para medir tempo entre frames
+    sf::Clock frameClock;
 
     // Um quadradinho para animar (placeholder do “herói”)
     sf::RectangleShape hero(sf::Vector2f{64.f, 64.f});
@@ -55,9 +57,12 @@ int main() {
     hero.setOrigin(sf::Vector2f{32.f, 32.f});                    // Vector2f
     hero.setPosition(sf::Vector2f{W * 0.5f, H * 0.5f});          // Vector2f
 
-    const float moveStep = 4.f;
+    const float moveSpeed = 200.f;
 
     while (window.isOpen()) {
+        sf::Time dt = frameClock.restart();
+        float moveStep = moveSpeed * dt.asSeconds();
+
         // pollEvent() retorna std::optional<Event>
         while (auto ev = window.pollEvent()) {
             if (ev->is<sf::Event::Closed>()) {


### PR DESCRIPTION
## Summary
- start `sf::Clock` to measure frame time and use delta for hero movement
- note the change in `[Unreleased]` of the changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e5e7f2c88327a275ec8d0786a768