### PR TITLE
feat: handle window and mouse events with sf::Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: movimento do “herói” controlado por teclas **W/A/S/D**.
 - `src/main.cpp`: logs de dimensões e camadas após carregar TMX.
 - `src/main.cpp`: mede tempo entre frames com `sf::Clock`.
+- `src/main.cpp`: uso de `sf::Event` no loop e clique do mouse posiciona o herói.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,13 +63,28 @@ int main() {
         sf::Time dt = frameClock.restart();
         float moveStep = moveSpeed * dt.asSeconds();
 
-        // pollEvent() retorna std::optional<Event>
-        while (auto ev = window.pollEvent()) {
-            if (ev->is<sf::Event::Closed>()) {
-                window.close();
-            } else if (ev->is<sf::Event::KeyPressed>() &&
-                       ev->getIf<sf::Event::KeyPressed>()->code == sf::Keyboard::Key::Escape) {
-                window.close();
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            switch (event.type) {
+                case sf::Event::Closed:
+                    window.close();
+                    break;
+
+                case sf::Event::KeyPressed:
+                    if (event.key.code == sf::Keyboard::Key::Escape) {
+                        window.close();
+                    }
+                    break;
+
+                case sf::Event::MouseButtonPressed:
+                    if (event.mouseButton.button == sf::Mouse::Left) {
+                        hero.setPosition(sf::Vector2f{static_cast<float>(event.mouseButton.x),
+                                                      static_cast<float>(event.mouseButton.y)});
+                    }
+                    break;
+
+                default:
+                    break;
             }
         }
 


### PR DESCRIPTION
## Summary
- use `sf::Event` with `window.pollEvent(event)` to process events
- move hero to mouse click position and close on Escape

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ed3a710083278b5fbb6fb471e052