### PR TITLE
refactor(runtime): capture frame delta time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: movimento do “herói” controlado por teclas **W/A/S/D**.
 - `src/main.cpp`: logs de dimensões e camadas após carregar TMX.
 - `src/main.cpp`: mede tempo entre frames com `sf::Clock`.
+- `src/main.cpp`: armazena `elapsed` e `deltaTime` no início de cada frame.
 - `src/main.cpp`: uso de `sf::Event` no loop e clique do mouse posiciona o herói.
 
 ### Fixed

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,8 +60,9 @@ int main() {
     const float moveSpeed = 200.f;
 
     while (window.isOpen()) {
-        sf::Time dt = frameClock.restart();
-        float moveStep = moveSpeed * dt.asSeconds();
+        sf::Time elapsed = frameClock.restart();
+        float deltaTime = elapsed.asSeconds();
+        float moveStep = moveSpeed * deltaTime;
 
         sf::Event event;
         while (window.pollEvent(event)) {


### PR DESCRIPTION
## Summary
- store elapsed time at frame start and derive deltaTime
- document change in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a8ee0d682883278ad9fca886802004