### PR TITLE
feat(runtime): add scene update with delta time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Regra de **cópia de assets** do `examples/hello-town/` para `bin/<Config>/game/`.
 - Mapa `first.tmx` e tileset simples em `examples/hello-town`.
 - Teste básico de inicialização com GoogleTest.
+- `src/scene.hpp` e `src/scene.cpp`: classe `Scene` com `update(deltaTime)`.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).
@@ -24,6 +25,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: mede tempo entre frames com `sf::Clock`.
 - `src/main.cpp`: armazena `elapsed` e `deltaTime` no início de cada frame.
 - `src/main.cpp`: uso de `sf::Event` no loop e clique do mouse posiciona o herói.
+- `src/main.cpp`: chama `scene.update(deltaTime)` para atualizar o herói.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 # ===== Fontes do exemplo =====
 set(HELLO_TOWN_SOURCES
   src/main.cpp
+  src/scene.cpp
 )
 
 add_executable(hello-town ${HELLO_TOWN_SOURCES})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <tmxlite/Map.hpp>
 #include <filesystem>
 #include <iostream>
+#include "scene.hpp"
 
 int main() {
     std::cout << "Lumy: hello-town iniciando...\n";
@@ -52,17 +53,11 @@ int main() {
     sf::Clock frameClock;
 
     // Um quadradinho para animar (placeholder do “herói”)
-    sf::RectangleShape hero(sf::Vector2f{64.f, 64.f});
-    hero.setFillColor(sf::Color::White);
-    hero.setOrigin(sf::Vector2f{32.f, 32.f});                    // Vector2f
-    hero.setPosition(sf::Vector2f{W * 0.5f, H * 0.5f});          // Vector2f
-
-    const float moveSpeed = 200.f;
+    Scene scene(sf::Vector2f{W * 0.5f, H * 0.5f});
 
     while (window.isOpen()) {
         sf::Time elapsed = frameClock.restart();
         float deltaTime = elapsed.asSeconds();
-        float moveStep = moveSpeed * deltaTime;
 
         sf::Event event;
         while (window.pollEvent(event)) {
@@ -77,27 +72,16 @@ int main() {
                     }
                     break;
 
-                case sf::Event::MouseButtonPressed:
-                    if (event.mouseButton.button == sf::Mouse::Left) {
-                        hero.setPosition(sf::Vector2f{static_cast<float>(event.mouseButton.x),
-                                                      static_cast<float>(event.mouseButton.y)});
-                    }
-                    break;
-
                 default:
                     break;
             }
+            scene.handleEvent(event);
         }
 
-        sf::Vector2f pos = hero.getPosition();
-        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::W)) pos.y -= moveStep;
-        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::S)) pos.y += moveStep;
-        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::A)) pos.x -= moveStep;
-        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::D)) pos.x += moveStep;
-        hero.setPosition(pos);
+        scene.update(deltaTime);
 
         window.clear(sf::Color::Black);
-        window.draw(hero);
+        scene.draw(window);
         window.display();
     }
 

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -1,0 +1,36 @@
+#include "scene.hpp"
+#include <SFML/Window/Keyboard.hpp>
+
+Scene::Scene(const sf::Vector2f& startPos) {
+    hero.setSize(sf::Vector2f{64.f, 64.f});
+    hero.setFillColor(sf::Color::White);
+    hero.setOrigin(sf::Vector2f{32.f, 32.f});
+    hero.setPosition(startPos);
+}
+
+void Scene::handleEvent(const sf::Event& event) {
+    if (event.type == sf::Event::MouseButtonPressed &&
+        event.mouseButton.button == sf::Mouse::Left) {
+        hero.setPosition(
+            sf::Vector2f{static_cast<float>(event.mouseButton.x),
+                          static_cast<float>(event.mouseButton.y)});
+    }
+}
+
+void Scene::update(float deltaTime) {
+    sf::Vector2f pos = hero.getPosition();
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::W))
+        pos.y -= moveSpeed * deltaTime;
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::S))
+        pos.y += moveSpeed * deltaTime;
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::A))
+        pos.x -= moveSpeed * deltaTime;
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::D))
+        pos.x += moveSpeed * deltaTime;
+    hero.setPosition(pos);
+}
+
+void Scene::draw(sf::RenderWindow& window) const {
+    window.draw(hero);
+}
+

--- a/src/scene.hpp
+++ b/src/scene.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+
+class Scene {
+public:
+    explicit Scene(const sf::Vector2f& startPos);
+
+    void handleEvent(const sf::Event& event);
+    void update(float deltaTime);
+    void draw(sf::RenderWindow& window) const;
+
+private:
+    sf::RectangleShape hero;
+    float moveSpeed = 200.f;
+};
+


### PR DESCRIPTION
## Summary
- create Scene class that updates movement with delta time
- call scene.update(deltaTime) in main loop
- register new scene source in build

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build directory missing)*
- `ctest --preset msvc-tests` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8eea7fce4832793821a8045c8a262