### PR TITLE
feat(runtime): limit FPS manually and log average FPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: armazena `elapsed` e `deltaTime` no início de cada frame.
 - `src/main.cpp`: uso de `sf::Event` no loop e clique do mouse posiciona o herói.
 - `src/main.cpp`: chama `scene.update(deltaTime)` para atualizar o herói.
+- `src/main.cpp`: limitador manual de 60 FPS com `sf::sleep` e log de FPS médio.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,10 +47,12 @@ int main() {
     // Janela SFML
     const unsigned W = 640, H = 360;
     sf::RenderWindow window(sf::VideoMode(sf::Vector2u{W, H}), "Lumy — hello-town");
-    window.setFramerateLimit(60);
 
-    // Clock para medir tempo entre frames
+    // Limitador manual de FPS
+    const sf::Time targetFrameTime = sf::seconds(1.f / 60.f);
     sf::Clock frameClock;
+    std::size_t fpsFrameCount = 0;
+    sf::Time fpsAccumulated = sf::Time::Zero;
 
     // Um quadradinho para animar (placeholder do “herói”)
     Scene scene(sf::Vector2f{W * 0.5f, H * 0.5f});
@@ -58,6 +60,16 @@ int main() {
     while (window.isOpen()) {
         sf::Time elapsed = frameClock.restart();
         float deltaTime = elapsed.asSeconds();
+
+        // Média de FPS a cada ~1 segundo
+        fpsFrameCount++;
+        fpsAccumulated += elapsed;
+        if (fpsAccumulated >= sf::seconds(1.f)) {
+            float avgFps = static_cast<float>(fpsFrameCount) / fpsAccumulated.asSeconds();
+            std::cout << "FPS médio: " << avgFps << "\n";
+            fpsFrameCount = 0;
+            fpsAccumulated = sf::Time::Zero;
+        }
 
         sf::Event event;
         while (window.pollEvent(event)) {
@@ -86,6 +98,12 @@ int main() {
         scene.draw(window);
         // 3. Exibir o frame
         window.display();
+
+        // Completar o tempo de frame restante
+        sf::Time workTime = frameClock.getElapsedTime();
+        if (workTime < targetFrameTime) {
+            sf::sleep(targetFrameTime - workTime);
+        }
     }
 
     std::cout << "Lumy: bye!\n";


### PR DESCRIPTION
## Summary
- add manual 60 FPS limiter using sf::sleep and track average FPS
- document FPS limiter and logging in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f17d790c83279072f900bd2e980b