### PR TITLE
feat(runtime): clamp deltaTime and log frame drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: uso de `sf::Event` no loop e clique do mouse posiciona o herói.
 - `src/main.cpp`: chama `scene.update(deltaTime)` para atualizar o herói.
 - `src/main.cpp`: limitador manual de 60 FPS com `sf::sleep` e log de FPS médio.
+- `src/main.cpp`: limita `deltaTime` a 30 FPS e registra quedas de frame.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,7 @@ int main() {
     sf::Clock frameClock;
     std::size_t fpsFrameCount = 0;
     sf::Time fpsAccumulated = sf::Time::Zero;
+    const float maxDeltaTime = 1.f / 30.f;
 
     // Um quadradinho para animar (placeholder do “herói”)
     Scene scene(sf::Vector2f{W * 0.5f, H * 0.5f});
@@ -60,6 +61,10 @@ int main() {
     while (window.isOpen()) {
         sf::Time elapsed = frameClock.restart();
         float deltaTime = elapsed.asSeconds();
+        if (deltaTime > maxDeltaTime) {
+            std::cout << "[Frame drop] deltaTime: " << deltaTime << "s\n";
+            deltaTime = maxDeltaTime;
+        }
 
         // Média de FPS a cada ~1 segundo
         fpsFrameCount++;


### PR DESCRIPTION
## Summary
- clamp deltaTime above 30 FPS to avoid jumps
- log frame drops when deltaTime exceeds limit

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion)*
- `cmake --build build/msvc --config Debug` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2b60678832792a9df37fe9e4cf2