### PR TITLE
refactor(runtime): handle events via optional pollEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: limitador manual de 60 FPS com `sf::sleep` e log de FPS médio.
 - `src/main.cpp`: limita `deltaTime` a 30 FPS e registra quedas de frame.
 - `src/main.cpp`: encerra o loop quando a janela fecha e libera objetos alocados.
+- `src/main.cpp`: loop de eventos usa `pollEvent()` opcional, checa tipos com `event->is` e repassa para a cena.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,24 +82,16 @@ int main() {
             fpsAccumulated = sf::Time::Zero;
         }
 
-        // FIX THIS
-        sf::Event event;
-        while (window->pollEvent(event)) {
-            switch (event.type) {
-                case sf::Event::Closed:
+        while (auto event = window->pollEvent()) {
+            if (event->is<sf::Event::Closed>()) {
+                window->close();
+            } else if (event->is<sf::Event::KeyPressed>()) {
+                auto key = event->get<sf::Event::KeyPressed>();
+                if (key.code == sf::Keyboard::Key::Escape) {
                     window->close();
-                    break;
-
-                case sf::Event::KeyPressed:
-                    if (event.key.code == sf::Keyboard::Key::Escape) {
-                        window->close();
-                    }
-                    break;
-
-                default:
-                    break;
+                }
             }
-            scene->handleEvent(event);
+            scene->handleEvent(*event);
         }
 
         scene->update(deltaTime);


### PR DESCRIPTION
## Summary
- use `window->pollEvent()` optional interface and dispatch to scene
- log changelog entry for new event loop

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8faa7c83c83278e3cca395f428cb7