### PR TITLE
fix(runtime): handle mouse click with variant event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: limita `deltaTime` a 30 FPS e registra quedas de frame.
 - `src/main.cpp`: encerra o loop quando a janela fecha e libera objetos alocados.
 - `src/main.cpp`: loop de eventos usa `pollEvent()` opcional, checa tipos com `event->is` e repassa para a cena.
+- `src/scene.cpp`: `handleEvent` usa `event.is`/`event.get` para cliques do mouse.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -1,5 +1,6 @@
 #include "scene.hpp"
 #include <SFML/Window/Keyboard.hpp>
+#include <SFML/Window/Event.hpp>
 
 Scene::Scene(const sf::Vector2f& startPos) {
     hero.setSize(sf::Vector2f{64.f, 64.f});
@@ -8,13 +9,14 @@ Scene::Scene(const sf::Vector2f& startPos) {
     hero.setPosition(startPos);
 }
 
-// FIX THIS
 void Scene::handleEvent(const sf::Event& event) {
-    if (event.type == sf::Event::MouseButtonPressed &&
-        event.mouseButton.button == sf::Mouse::Left) {
-        hero.setPosition(
-            sf::Vector2f{static_cast<float>(event.mouseButton.x),
-                          static_cast<float>(event.mouseButton.y)});
+    if (event.is<sf::Event::MouseButtonPressed>()) {
+        auto mouse = event.get<sf::Event::MouseButtonPressed>();
+        if (mouse.button == sf::Mouse::Left) {
+            hero.setPosition(sf::Vector2f{
+                static_cast<float>(mouse.position.x),
+                static_cast<float>(mouse.position.y)});
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- handle mouse clicks using `event.is` and `event.get`
- note the change in the changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build directory missing)*
- `./build/msvc/bin/Debug/hello-town` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fc6c56ac8327a9442de2e85cf4b4