### PR TITLE
refactor(runtime): check window status in main loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: limita `deltaTime` a 30 FPS e registra quedas de frame.
 - `src/main.cpp`: encerra o loop quando a janela fecha e libera objetos alocados.
 - `src/main.cpp`: loop de eventos usa `pollEvent()` opcional, checa tipos com `event->is` e repassa para a cena.
+- `src/main.cpp`: condiciona loop à janela aberta e verifica fechamento após eventos.
 - `src/scene.cpp`: `handleEvent` usa `event.is`/`event.get` para cliques do mouse.
 
 ### Fixed

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,11 +60,7 @@ int main() {
     // Um quadradinho para animar (placeholder do “herói”)
     auto scene = std::make_unique<Scene>(sf::Vector2f{W * 0.5f, H * 0.5f});
 
-    while (true) {
-        if (!window->isOpen()) {
-            break;
-        }
-
+    while (window->isOpen()) {
         sf::Time elapsed = frameClock.restart();
         float deltaTime = elapsed.asSeconds();
         if (deltaTime > maxDeltaTime) {
@@ -92,6 +88,10 @@ int main() {
                 }
             }
             scene->handleEvent(*event);
+        }
+
+        if (!window->isOpen()) {
+            break;
         }
 
         scene->update(deltaTime);


### PR DESCRIPTION
## Summary
- use `window->isOpen()` as loop condition
- remove redundant open check and break after events
- document change in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Could not read presets, Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a90a750b3c832784c9b5ae58520f93