### PR TITLE
refactor(runtime): simplify event handling with getIf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: limitador manual de 60 FPS com `sf::sleep` e log de FPS médio.
 - `src/main.cpp`: limita `deltaTime` a 30 FPS e registra quedas de frame.
 - `src/main.cpp`: encerra o loop quando a janela fecha e libera objetos alocados.
-- `src/main.cpp`: loop de eventos usa `pollEvent()` opcional, checa tipos com `event->is` e repassa para a cena.
+- `src/main.cpp`: loop de eventos usa `pollEvent()` opcional, checa `Closed` com `event->is` e lê tecla Escape com `getIf`, repassando para a cena.
 - `src/main.cpp`: condiciona loop à janela aberta e verifica fechamento após eventos.
-- `src/scene.cpp`: `handleEvent` usa `event.is`/`event.get` para cliques do mouse.
+- `src/scene.cpp`: `handleEvent` usa ponteiro retornado por `getIf` para cliques do mouse.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,9 +81,9 @@ int main() {
         while (auto event = window->pollEvent()) {
             if (event->is<sf::Event::Closed>()) {
                 window->close();
-            } else if (event->is<sf::Event::KeyPressed>()) {
-                auto key = event->getIf<sf::Event::KeyPressed>();
-                if (key.code == sf::Keyboard::Key::Escape) {
+            }
+            if (const auto* key = event->getIf<sf::Event::KeyPressed>()) {
+                if (key->code == sf::Keyboard::Key::Escape) {
                     window->close();
                 }
             }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -10,12 +10,10 @@ Scene::Scene(const sf::Vector2f& startPos) {
 }
 
 void Scene::handleEvent(const sf::Event& event) {
-    if (event.is<sf::Event::MouseButtonPressed>()) {
-        auto mouse = event.getIf<sf::Event::MouseButtonPressed>();
-        if (mouse.button == sf::Mouse::Left) {
-            hero.setPosition(sf::Vector2f{
-                static_cast<float>(mouse.position.x),
-                static_cast<float>(mouse.position.y)});
+    if (const auto* mouse = event.getIf<sf::Event::MouseButtonPressed>()) {
+        if (mouse->button == sf::Mouse::Left) {
+            hero.setPosition({static_cast<float>(mouse->position.x),
+                              static_cast<float>(mouse->position.y)});
         }
     }
 }


### PR DESCRIPTION
## Summary
- simplify key press handling in main loop using `getIf`
- streamline mouse event handling in scene
- document event handling refactor in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a90b3d7f18832782cbbb3cd28e995e