### PR TITLE
feat(runtime): add SceneStack and refactor main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Mapa `first.tmx` e tileset simples em `examples/hello-town`.
 - Teste básico de inicialização com GoogleTest.
 - `src/scene.hpp` e `src/scene.cpp`: classe `Scene` com `update(deltaTime)`.
+- `src/scene_stack.hpp` e `src/scene_stack.cpp`: pilha de cenas com push/pop/switch.
+- Testes para `SceneStack`.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).
@@ -32,6 +34,9 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: loop de eventos usa `pollEvent()` opcional, checa `Closed` com `event->is` e lê tecla Escape com `getIf`, repassando para a cena.
 - `src/main.cpp`: condiciona loop à janela aberta e verifica fechamento após eventos.
 - `src/scene.cpp`: `handleEvent` usa ponteiro retornado por `getIf` para cliques do mouse.
+- `src/scene.hpp`: agora serve como classe-base com destrutor e métodos virtuais.
+- `src/main.cpp`: usa `SceneStack` para gerenciar cenas.
+- `CMakeLists.txt`: compila `SceneStack` e adiciona testes.
 - `src/scene.cpp`: correção de sf::Mouse::Left para sf::Mouse::Button::Left da SFML3.
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 set(HELLO_TOWN_SOURCES
   src/main.cpp
   src/scene.cpp
+  src/scene_stack.cpp
 )
 
 add_executable(hello-town ${HELLO_TOWN_SOURCES})
@@ -74,8 +75,14 @@ endif()
 # ===== Tests =====
 enable_testing()
 find_package(GTest CONFIG REQUIRED)
-add_executable(lumy-tests tests/basic_startup.cpp)
+add_executable(lumy-tests
+  tests/basic_startup.cpp
+  tests/scene_stack.cpp
+  src/scene.cpp
+  src/scene_stack.cpp
+)
 target_link_libraries(lumy-tests PRIVATE GTest::gtest_main SFML::Graphics)
+target_include_directories(lumy-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME basic_startup COMMAND lumy-tests)
 
 # ===== Instalação opcional =====

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@
 - [ ] Definir esquemas **JSON** (actors/items/states/skills/enemies/system). *(Planned)*
 - [ ] Tabela de **comandos de evento** (10 básicos) com argumentos. *(Planned)*
 - [ ] Carregar **TMX** via tmxlite; desenhar layers e flags de colisão. *(Planned)*
-- [ ] Implementar **SceneStack** e ciclo de jogo. *(Planned)*
+ - [x] Implementar **SceneStack** e ciclo de jogo. *(Done)*
 - [ ] **Save/Load** de switches/variáveis/posição. *(Planned)*
 - [ ] Exemplo `hello-town` + README. *(Planned)*
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <memory>
 #include "scene.hpp"
+#include "scene_stack.hpp"
 
 int main() {
     std::cout << "Lumy: hello-town iniciando...\n";
@@ -58,7 +59,8 @@ int main() {
     const float maxDeltaTime = 1.f / 30.f;
 
     // Um quadradinho para animar (placeholder do “herói”)
-    auto scene = std::make_unique<Scene>(sf::Vector2f{W * 0.5f, H * 0.5f});
+    SceneStack stack;
+    stack.pushScene(std::make_unique<Scene>(sf::Vector2f{W * 0.5f, H * 0.5f}));
 
     while (window->isOpen()) {
         sf::Time elapsed = frameClock.restart();
@@ -87,19 +89,25 @@ int main() {
                     window->close();
                 }
             }
-            scene->handleEvent(*event);
+            if (auto* current = stack.current()) {
+                current->handleEvent(*event);
+            }
         }
 
         if (!window->isOpen()) {
             break;
         }
 
-        scene->update(deltaTime);
+        if (auto* current = stack.current()) {
+            current->update(deltaTime);
+        }
 
         // 1. Limpar a tela
         window->clear(sf::Color::Black);
         // 2. Desenhar objetos
-        scene->draw(*window);
+        if (auto* current = stack.current()) {
+            current->draw(*window);
+        }
         // 3. Exibir o frame
         window->display();
 
@@ -110,7 +118,6 @@ int main() {
         }
     }
 
-    scene.reset();
     window.reset();
 
     std::cout << "Lumy: bye!\n";

--- a/src/scene.hpp
+++ b/src/scene.hpp
@@ -5,10 +5,11 @@
 class Scene {
 public:
     explicit Scene(const sf::Vector2f& startPos);
+    virtual ~Scene() = default;
 
-    void handleEvent(const sf::Event& event);
-    void update(float deltaTime);
-    void draw(sf::RenderWindow& window) const;
+    virtual void handleEvent(const sf::Event& event);
+    virtual void update(float deltaTime);
+    virtual void draw(sf::RenderWindow& window) const;
 
 private:
     sf::RectangleShape hero;

--- a/src/scene_stack.cpp
+++ b/src/scene_stack.cpp
@@ -1,0 +1,24 @@
+#include "scene_stack.hpp"
+
+void SceneStack::pushScene(std::unique_ptr<Scene> scene) {
+    stack_.push_back(std::move(scene));
+}
+
+void SceneStack::popScene() {
+    if (!stack_.empty()) {
+        stack_.pop_back();
+    }
+}
+
+void SceneStack::switchScene(std::unique_ptr<Scene> scene) {
+    if (!stack_.empty()) {
+        stack_.back() = std::move(scene);
+    } else {
+        stack_.push_back(std::move(scene));
+    }
+}
+
+Scene* SceneStack::current() const {
+    return stack_.empty() ? nullptr : stack_.back().get();
+}
+

--- a/src/scene_stack.hpp
+++ b/src/scene_stack.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "scene.hpp"
+
+class SceneStack {
+public:
+    void pushScene(std::unique_ptr<Scene> scene);
+    void popScene();
+    void switchScene(std::unique_ptr<Scene> scene);
+    Scene* current() const;
+
+private:
+    std::vector<std::unique_ptr<Scene>> stack_;
+};
+

--- a/tests/scene_stack.cpp
+++ b/tests/scene_stack.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include "scene_stack.hpp"
+
+TEST(SceneStack, PushPopSwitch) {
+    SceneStack stack;
+
+    auto first = std::make_unique<Scene>(sf::Vector2f{0.f, 0.f});
+    Scene* firstPtr = first.get();
+    stack.pushScene(std::move(first));
+    EXPECT_EQ(stack.current(), firstPtr);
+
+    auto second = std::make_unique<Scene>(sf::Vector2f{1.f, 1.f});
+    Scene* secondPtr = second.get();
+    stack.pushScene(std::move(second));
+    EXPECT_EQ(stack.current(), secondPtr);
+
+    stack.popScene();
+    EXPECT_EQ(stack.current(), firstPtr);
+
+    stack.popScene();
+    EXPECT_EQ(stack.current(), nullptr);
+
+    stack.popScene();
+    EXPECT_EQ(stack.current(), nullptr);
+
+    auto third = std::make_unique<Scene>(sf::Vector2f{2.f, 2.f});
+    Scene* thirdPtr = third.get();
+    stack.switchScene(std::move(third));
+    EXPECT_EQ(stack.current(), thirdPtr);
+
+    auto fourth = std::make_unique<Scene>(sf::Vector2f{3.f, 3.f});
+    Scene* fourthPtr = fourth.get();
+    stack.switchScene(std::move(fourth));
+    EXPECT_EQ(stack.current(), fourthPtr);
+}
+


### PR DESCRIPTION
## Summary
- add SceneStack for managing active scenes
- make Scene a base class and refactor main to use SceneStack
- test scene stack operations

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: directory does not exist)*
- `ctest --test-dir build/msvc` *(fails: directory does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a917fa36e48327918283d7982eb5bc