### PR TITLE
refactor(runtime): extract MapScene from Scene base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/scene.hpp` e `src/scene.cpp`: classe `Scene` com `update(deltaTime)`.
 - `src/scene_stack.hpp` e `src/scene_stack.cpp`: pilha de cenas com push/pop/switch.
 - Testes para `SceneStack`.
+- `src/map_scene.hpp` e `src/map_scene.cpp`: classe `MapScene` com lógica do herói.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).
@@ -34,7 +35,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: loop de eventos usa `pollEvent()` opcional, checa `Closed` com `event->is` e lê tecla Escape com `getIf`, repassando para a cena.
 - `src/main.cpp`: condiciona loop à janela aberta e verifica fechamento após eventos.
 - `src/scene.cpp`: `handleEvent` usa ponteiro retornado por `getIf` para cliques do mouse.
-- `src/scene.hpp`: agora serve como classe-base com destrutor e métodos virtuais.
+- `src/scene.hpp`/`src/scene.cpp`: `Scene` agora é abstrata e delega lógica à `MapScene`.
 - `src/main.cpp`: usa `SceneStack` para gerenciar cenas.
 - `CMakeLists.txt`: compila `SceneStack` e adiciona testes.
 - `src/scene.cpp`: correção de sf::Mouse::Left para sf::Mouse::Button::Left da SFML3.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(HELLO_TOWN_SOURCES
   src/main.cpp
   src/scene.cpp
   src/scene_stack.cpp
+  src/map_scene.cpp
 )
 
 add_executable(hello-town ${HELLO_TOWN_SOURCES})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
-#include "scene.hpp"
+#include "map_scene.hpp"
 #include "scene_stack.hpp"
 
 int main() {
@@ -60,7 +60,7 @@ int main() {
 
     // Um quadradinho para animar (placeholder do “herói”)
     SceneStack stack;
-    stack.pushScene(std::make_unique<Scene>(sf::Vector2f{W * 0.5f, H * 0.5f}));
+    stack.pushScene(std::make_unique<MapScene>(sf::Vector2f{W * 0.5f, H * 0.5f}));
 
     while (window->isOpen()) {
         sf::Time elapsed = frameClock.restart();

--- a/src/map_scene.cpp
+++ b/src/map_scene.cpp
@@ -1,0 +1,36 @@
+#include "map_scene.hpp"
+#include <SFML/Window/Keyboard.hpp>
+#include <SFML/Window/Event.hpp>
+
+MapScene::MapScene(const sf::Vector2f& startPos) {
+    hero_.setSize(sf::Vector2f{64.f, 64.f});
+    hero_.setFillColor(sf::Color::White);
+    hero_.setOrigin(sf::Vector2f{32.f, 32.f});
+    hero_.setPosition(startPos);
+}
+
+void MapScene::handleEvent(const sf::Event& event) {
+    if (const auto* mouse = event.getIf<sf::Event::MouseButtonPressed>()) {
+        if (mouse->button == sf::Mouse::Button::Left) {
+            hero_.setPosition({static_cast<float>(mouse->position.x),
+                               static_cast<float>(mouse->position.y)});
+        }
+    }
+}
+
+void MapScene::update(float deltaTime) {
+    sf::Vector2f pos = hero_.getPosition();
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::W))
+        pos.y -= moveSpeed_ * deltaTime;
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::S))
+        pos.y += moveSpeed_ * deltaTime;
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::A))
+        pos.x -= moveSpeed_ * deltaTime;
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::D))
+        pos.x += moveSpeed_ * deltaTime;
+    hero_.setPosition(pos);
+}
+
+void MapScene::draw(sf::RenderWindow& window) const {
+    window.draw(hero_);
+}

--- a/src/map_scene.hpp
+++ b/src/map_scene.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "scene.hpp"
+#include <SFML/Graphics.hpp>
+
+class MapScene : public Scene {
+public:
+    explicit MapScene(const sf::Vector2f& startPos);
+
+    void handleEvent(const sf::Event& event) override;
+    void update(float deltaTime) override;
+    void draw(sf::RenderWindow& window) const override;
+
+private:
+    sf::RectangleShape hero_;
+    float moveSpeed_ = 200.f;
+};

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -1,37 +1,3 @@
 #include "scene.hpp"
-#include <SFML/Window/Keyboard.hpp>
-#include <SFML/Window/Event.hpp>
 
-Scene::Scene(const sf::Vector2f& startPos) {
-    hero.setSize(sf::Vector2f{64.f, 64.f});
-    hero.setFillColor(sf::Color::White);
-    hero.setOrigin(sf::Vector2f{32.f, 32.f});
-    hero.setPosition(startPos);
-}
-
-void Scene::handleEvent(const sf::Event& event) {
-    if (const auto* mouse = event.getIf<sf::Event::MouseButtonPressed>()) {
-        if (mouse->button == sf::Mouse::Button::Left) {
-            hero.setPosition({static_cast<float>(mouse->position.x),
-                              static_cast<float>(mouse->position.y)});
-        }
-    }
-}
-
-void Scene::update(float deltaTime) {
-    sf::Vector2f pos = hero.getPosition();
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::W))
-        pos.y -= moveSpeed * deltaTime;
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::S))
-        pos.y += moveSpeed * deltaTime;
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::A))
-        pos.x -= moveSpeed * deltaTime;
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::D))
-        pos.x += moveSpeed * deltaTime;
-    hero.setPosition(pos);
-}
-
-void Scene::draw(sf::RenderWindow& window) const {
-    window.draw(hero);
-}
-
+Scene::~Scene() = default;

--- a/src/scene.hpp
+++ b/src/scene.hpp
@@ -4,15 +4,11 @@
 
 class Scene {
 public:
-    explicit Scene(const sf::Vector2f& startPos);
-    virtual ~Scene() = default;
+    Scene() = default;
+    virtual ~Scene();
 
-    virtual void handleEvent(const sf::Event& event);
-    virtual void update(float deltaTime);
-    virtual void draw(sf::RenderWindow& window) const;
-
-private:
-    sf::RectangleShape hero;
-    float moveSpeed = 200.f;
+    virtual void handleEvent(const sf::Event& event) = 0;
+    virtual void update(float deltaTime) = 0;
+    virtual void draw(sf::RenderWindow& window) const = 0;
 };
 

--- a/tests/scene_stack.cpp
+++ b/tests/scene_stack.cpp
@@ -1,15 +1,24 @@
 #include <gtest/gtest.h>
 #include "scene_stack.hpp"
 
+namespace {
+class DummyScene : public Scene {
+public:
+    void handleEvent(const sf::Event&) override {}
+    void update(float) override {}
+    void draw(sf::RenderWindow&) const override {}
+};
+} // namespace
+
 TEST(SceneStack, PushPopSwitch) {
     SceneStack stack;
 
-    auto first = std::make_unique<Scene>(sf::Vector2f{0.f, 0.f});
+    auto first = std::make_unique<DummyScene>();
     Scene* firstPtr = first.get();
     stack.pushScene(std::move(first));
     EXPECT_EQ(stack.current(), firstPtr);
 
-    auto second = std::make_unique<Scene>(sf::Vector2f{1.f, 1.f});
+    auto second = std::make_unique<DummyScene>();
     Scene* secondPtr = second.get();
     stack.pushScene(std::move(second));
     EXPECT_EQ(stack.current(), secondPtr);
@@ -23,12 +32,12 @@ TEST(SceneStack, PushPopSwitch) {
     stack.popScene();
     EXPECT_EQ(stack.current(), nullptr);
 
-    auto third = std::make_unique<Scene>(sf::Vector2f{2.f, 2.f});
+    auto third = std::make_unique<DummyScene>();
     Scene* thirdPtr = third.get();
     stack.switchScene(std::move(third));
     EXPECT_EQ(stack.current(), thirdPtr);
 
-    auto fourth = std::make_unique<Scene>(sf::Vector2f{3.f, 3.f});
+    auto fourth = std::make_unique<DummyScene>();
     Scene* fourthPtr = fourth.get();
     stack.switchScene(std::move(fourth));
     EXPECT_EQ(stack.current(), fourthPtr);


### PR DESCRIPTION
## Summary
- make Scene an abstract interface with pure virtual event, update, and draw methods
- introduce MapScene that owns the hero and movement logic
- adjust main, SceneStack tests, and build files for new MapScene

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion)*
- `cmake --build build/msvc --config Debug` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a91f68d04883278b5f2552f19cbab2