### PR TITLE
feat: add boot and title scenes with scene transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/scene_stack.hpp` e `src/scene_stack.cpp`: pilha de cenas com push/pop/switch.
 - Testes para `SceneStack`.
 - `src/map_scene.hpp` e `src/map_scene.cpp`: classe `MapScene` com lógica do herói.
+- `src/boot_scene.hpp`/`src/boot_scene.cpp`: cena de boot que carrega recursos e vai para `TitleScene`.
+- `src/title_scene.hpp`/`src/title_scene.cpp`: menu de título com opção Start que abre `MapScene`.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).
@@ -39,6 +41,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: usa `SceneStack` para gerenciar cenas.
 - `CMakeLists.txt`: compila `SceneStack` e adiciona testes.
 - `src/scene.cpp`: correção de sf::Mouse::Left para sf::Mouse::Button::Left da SFML3.
+- `src/main.cpp`: fluxo de cenas Boot → Title → Map via `SceneStack`.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(HELLO_TOWN_SOURCES
   src/main.cpp
   src/scene.cpp
   src/scene_stack.cpp
+  src/boot_scene.cpp
+  src/title_scene.cpp
   src/map_scene.cpp
 )
 

--- a/src/boot_scene.cpp
+++ b/src/boot_scene.cpp
@@ -1,0 +1,19 @@
+#include "boot_scene.hpp"
+#include "title_scene.hpp"
+#include <iostream>
+#include <memory>
+
+BootScene::BootScene(SceneStack& stack) : stack_(stack) {}
+
+void BootScene::handleEvent(const sf::Event&) {}
+
+void BootScene::update(float) {
+    if (!loaded_) {
+        std::cout << "BootScene: loading core resources...\n";
+        loaded_ = true;
+        stack_.switchScene(std::make_unique<TitleScene>(stack_));
+    }
+}
+
+void BootScene::draw(sf::RenderWindow&) const {}
+

--- a/src/boot_scene.hpp
+++ b/src/boot_scene.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "scene.hpp"
+#include "scene_stack.hpp"
+
+class BootScene : public Scene {
+public:
+    explicit BootScene(SceneStack& stack);
+
+    void handleEvent(const sf::Event& event) override;
+    void update(float deltaTime) override;
+    void draw(sf::RenderWindow& window) const override;
+
+private:
+    SceneStack& stack_;
+    bool loaded_ = false;
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
-#include "map_scene.hpp"
+#include "boot_scene.hpp"
 #include "scene_stack.hpp"
 
 int main() {
@@ -58,9 +58,9 @@ int main() {
     sf::Time fpsAccumulated = sf::Time::Zero;
     const float maxDeltaTime = 1.f / 30.f;
 
-    // Um quadradinho para animar (placeholder do “herói”)
+    // Pilha de cenas: inicia em BootScene
     SceneStack stack;
-    stack.pushScene(std::make_unique<MapScene>(sf::Vector2f{W * 0.5f, H * 0.5f}));
+    stack.pushScene(std::make_unique<BootScene>(stack));
 
     while (window->isOpen()) {
         sf::Time elapsed = frameClock.restart();

--- a/src/title_scene.cpp
+++ b/src/title_scene.cpp
@@ -1,0 +1,34 @@
+#include "title_scene.hpp"
+#include "map_scene.hpp"
+#include <memory>
+
+TitleScene::TitleScene(SceneStack& stack) : stack_(stack) {
+    font_.loadFromFile("game/font.ttf");
+    startText_.setFont(font_);
+    startText_.setString("Start");
+    startText_.setCharacterSize(32);
+    startText_.setPosition({200.f, 150.f});
+}
+
+void TitleScene::handleEvent(const sf::Event& event) {
+    if (const auto* key = event.getIf<sf::Event::KeyPressed>()) {
+        if (key->code == sf::Keyboard::Key::Enter) {
+            stack_.switchScene(std::make_unique<MapScene>(sf::Vector2f{320.f, 180.f}));
+        }
+    } else if (const auto* mouse = event.getIf<sf::Event::MouseButtonPressed>()) {
+        if (mouse->button == sf::Mouse::Button::Left) {
+            auto bounds = startText_.getGlobalBounds();
+            if (bounds.contains(static_cast<float>(mouse->position.x),
+                                static_cast<float>(mouse->position.y))) {
+                stack_.switchScene(std::make_unique<MapScene>(sf::Vector2f{320.f, 180.f}));
+            }
+        }
+    }
+}
+
+void TitleScene::update(float) {}
+
+void TitleScene::draw(sf::RenderWindow& window) const {
+    window.draw(startText_);
+}
+

--- a/src/title_scene.hpp
+++ b/src/title_scene.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "scene.hpp"
+#include "scene_stack.hpp"
+#include <SFML/Graphics.hpp>
+
+class TitleScene : public Scene {
+public:
+    explicit TitleScene(SceneStack& stack);
+
+    void handleEvent(const sf::Event& event) override;
+    void update(float deltaTime) override;
+    void draw(sf::RenderWindow& window) const override;
+
+private:
+    SceneStack& stack_;
+    sf::Font font_;
+    sf::Text startText_;
+};
+


### PR DESCRIPTION
## Summary
- add BootScene to load resources then jump to TitleScene
- add TitleScene menu that starts MapScene
- start program in BootScene and wire sources in CMake

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest --test-dir build/msvc` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a920cac2f083278b1eeecf4fe09928