### PR TITLE
test: add scene flow integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/map_scene.hpp` e `src/map_scene.cpp`: classe `MapScene` com lógica do herói.
 - `src/boot_scene.hpp`/`src/boot_scene.cpp`: cena de boot que carrega recursos e vai para `TitleScene`.
 - `src/title_scene.hpp`/`src/title_scene.cpp`: menu de título com opção Start que abre `MapScene`.
+- Teste de fluxo de cenas Boot → Title → Map.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,12 @@ find_package(GTest CONFIG REQUIRED)
 add_executable(lumy-tests
   tests/basic_startup.cpp
   tests/scene_stack.cpp
+  tests/scene_flow.cpp
   src/scene.cpp
   src/scene_stack.cpp
+  src/boot_scene.cpp
+  src/title_scene.cpp
+  src/map_scene.cpp
 )
 target_link_libraries(lumy-tests PRIVATE GTest::gtest_main SFML::Graphics)
 target_include_directories(lumy-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/tests/scene_flow.cpp
+++ b/tests/scene_flow.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "boot_scene.hpp"
+#include "map_scene.hpp"
+#include "scene_stack.hpp"
+#include "title_scene.hpp"
+
+TEST(SceneFlow, BootTitleMap) {
+    SceneStack stack;
+    stack.pushScene(std::make_unique<BootScene>(stack));
+    EXPECT_NE(dynamic_cast<BootScene*>(stack.current()), nullptr);
+
+    stack.current()->update(0.f);
+    EXPECT_NE(dynamic_cast<TitleScene*>(stack.current()), nullptr);
+
+    const sf::Event event = sf::Event::KeyPressed{sf::Keyboard::Key::Enter};
+    stack.current()->handleEvent(event);
+    EXPECT_NE(dynamic_cast<MapScene*>(stack.current()), nullptr);
+}
+


### PR DESCRIPTION
## Summary
- add integration test for BootScene -> TitleScene -> MapScene
- wire up scene sources to test target
- note new test in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest --test-dir build/msvc` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a923f62cf48327b476c751818ff0f3