### PR TITLE
docs: explain scene flow and SceneStack usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `README.md`: descrição da engine e passos básicos com `CMakePresets.json`.
 - `ROADMAP.md`: histórico atualizado após revisão do README.
 - `src/main.cpp`: comentários explicando a sequência de renderização (limpar → desenhar → exibir).
+- `docs/scene_flow.md` e `README.md`: fluxo Boot → Title → Map e uso do `SceneStack`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ build/msvc/bin/Debug/hello-town.exe
 ```
 
 No VS Code, selecione os mesmos presets e depure o alvo `hello-town` com `F5`.
+
+
+## Fluxo de cenas
+
+O exemplo `hello-town` usa `SceneStack` com as cenas Boot → Title → Map. `BootScene` carrega recursos e muda para `TitleScene`, que exibe "Start" (requer `game/font.ttf`) e ao confirmar abre `MapScene` com um herói movido por W/A/S/D.
+
+Veja [docs/scene_flow.md](docs/scene_flow.md) para detalhes.

--- a/docs/scene_flow.md
+++ b/docs/scene_flow.md
@@ -1,0 +1,37 @@
+# Fluxo de Cenas — Lumy (Boot → Title → Map)
+
+Este documento descreve o fluxo de cenas do exemplo `hello-town` e como usar o `SceneStack`.
+
+## Cenas
+
+1. **BootScene** — carrega recursos essenciais e troca imediatamente para `TitleScene`.
+2. **TitleScene** — exibe o texto "Start" usando a fonte `game/font.ttf`. Pressione **Enter** ou clique para ir para `MapScene`.
+3. **MapScene** — mostra um herói quadrado que se move com **W/A/S/D** ou cliques do mouse.
+
+## Assets necessários
+
+- `game/font.ttf` — qualquer fonte TrueType para renderizar o texto da `TitleScene`.
+- opcional: `game/first.tmx` — mapa de exemplo utilizado apenas para logs de carregamento.
+
+## Uso básico de `SceneStack`
+
+```cpp
+SceneStack stack;
+stack.pushScene(std::make_unique<BootScene>(stack));
+
+while (window.isOpen()) {
+    while (auto event = window.pollEvent()) {
+        if (auto* scene = stack.current()) {
+            scene->handleEvent(*event);
+        }
+    }
+
+    if (auto* scene = stack.current()) {
+        scene->update(deltaTime);
+        scene->draw(window);
+    }
+}
+```
+
+O `SceneStack` mantém apenas a cena ativa no topo e permite `pushScene`, `popScene` e `switchScene` para transições simples.
+


### PR DESCRIPTION
## Summary
- add scene flow doc describing Boot → Title → Map and SceneStack usage
- mention required assets for Boot/Title/Map scenes
- link doc from README and update changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*
- `ctest --test-dir build/msvc` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9250b0b748327af7057546a9a992e