### PR TITLE
fix(runtime): update TitleScene text setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/scene.cpp`: correção de sf::Mouse::Left para sf::Mouse::Button::Left da SFML3.
 - `src/main.cpp`: fluxo de cenas Boot → Title → Map via `SceneStack`.
 - `src/main.cpp`: inicia `SceneStack` com `BootScene`.
+- `src/title_scene.cpp`: usa `openFromFile`, inicializa `startText` no construtor e verifica cliques com `sf::Vector2f`.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/title_scene.cpp
+++ b/src/title_scene.cpp
@@ -2,11 +2,9 @@
 #include "map_scene.hpp"
 #include <memory>
 
-TitleScene::TitleScene(SceneStack& stack) : stack_(stack) {
-    font_.loadFromFile("game/font.ttf");
-    startText_.setFont(font_);
-    startText_.setString("Start");
-    startText_.setCharacterSize(32);
+TitleScene::TitleScene(SceneStack& stack)
+    : stack_(stack), startText_(font_, "Start", 32) {
+    font_.openFromFile("game/font.ttf");
     startText_.setPosition({200.f, 150.f});
 }
 
@@ -18,8 +16,8 @@ void TitleScene::handleEvent(const sf::Event& event) {
     } else if (const auto* mouse = event.getIf<sf::Event::MouseButtonPressed>()) {
         if (mouse->button == sf::Mouse::Button::Left) {
             auto bounds = startText_.getGlobalBounds();
-            if (bounds.contains(static_cast<float>(mouse->position.x),
-                                static_cast<float>(mouse->position.y))) {
+            if (bounds.contains(sf::Vector2f{static_cast<float>(mouse->position.x),
+                                            static_cast<float>(mouse->position.y)})) {
                 stack_.switchScene(std::make_unique<MapScene>(sf::Vector2f{320.f, 180.f}));
             }
         }


### PR DESCRIPTION
## Summary
- switch TitleScene to `openFromFile`
- construct start text during initialization and use `sf::Vector2f` in contains check

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Could not read presets)*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a929a6d74483279fbb40d845399ffd