### PR TITLE
feat(runtime): defer scene transitions via pending actions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,8 @@ int main() {
         // 3. Exibir o frame
         window->display();
 
+        stack.applyPending();
+
         // Completar o tempo de frame restante
         sf::Time workTime = frameClock.getElapsedTime();
         if (workTime < targetFrameTime) {

--- a/src/scene_stack.hpp
+++ b/src/scene_stack.hpp
@@ -7,12 +7,21 @@
 
 class SceneStack {
 public:
+    enum class ActionType { Push, Pop, Switch };
+
+    struct PendingAction {
+        ActionType type;
+        std::unique_ptr<Scene> scene;
+    };
+
     void pushScene(std::unique_ptr<Scene> scene);
     void popScene();
     void switchScene(std::unique_ptr<Scene> scene);
     Scene* current() const;
+    void applyPending();
 
 private:
     std::vector<std::unique_ptr<Scene>> stack_;
+    std::vector<PendingAction> pendingActions_;
 };
 

--- a/tests/scene_flow.cpp
+++ b/tests/scene_flow.cpp
@@ -9,13 +9,19 @@
 TEST(SceneFlow, BootTitleMap) {
     SceneStack stack;
     stack.pushScene(std::make_unique<BootScene>(stack));
+    EXPECT_EQ(stack.current(), nullptr);
+    stack.applyPending();
     EXPECT_NE(dynamic_cast<BootScene*>(stack.current()), nullptr);
 
     stack.current()->update(0.f);
+    EXPECT_NE(dynamic_cast<BootScene*>(stack.current()), nullptr);
+    stack.applyPending();
     EXPECT_NE(dynamic_cast<TitleScene*>(stack.current()), nullptr);
 
     const sf::Event event = sf::Event::KeyPressed{sf::Keyboard::Key::Enter};
     stack.current()->handleEvent(event);
+    EXPECT_NE(dynamic_cast<TitleScene*>(stack.current()), nullptr);
+    stack.applyPending();
     EXPECT_NE(dynamic_cast<MapScene*>(stack.current()), nullptr);
 }
 

--- a/tests/scene_stack.cpp
+++ b/tests/scene_stack.cpp
@@ -16,30 +16,44 @@ TEST(SceneStack, PushPopSwitch) {
     auto first = std::make_unique<DummyScene>();
     Scene* firstPtr = first.get();
     stack.pushScene(std::move(first));
+    EXPECT_EQ(stack.current(), nullptr);
+    stack.applyPending();
     EXPECT_EQ(stack.current(), firstPtr);
 
     auto second = std::make_unique<DummyScene>();
     Scene* secondPtr = second.get();
     stack.pushScene(std::move(second));
+    EXPECT_EQ(stack.current(), firstPtr);
+    stack.applyPending();
     EXPECT_EQ(stack.current(), secondPtr);
 
     stack.popScene();
+    EXPECT_EQ(stack.current(), secondPtr);
+    stack.applyPending();
     EXPECT_EQ(stack.current(), firstPtr);
 
     stack.popScene();
+    EXPECT_EQ(stack.current(), firstPtr);
+    stack.applyPending();
     EXPECT_EQ(stack.current(), nullptr);
 
     stack.popScene();
+    EXPECT_EQ(stack.current(), nullptr);
+    stack.applyPending();
     EXPECT_EQ(stack.current(), nullptr);
 
     auto third = std::make_unique<DummyScene>();
     Scene* thirdPtr = third.get();
     stack.switchScene(std::move(third));
+    EXPECT_EQ(stack.current(), nullptr);
+    stack.applyPending();
     EXPECT_EQ(stack.current(), thirdPtr);
 
     auto fourth = std::make_unique<DummyScene>();
     Scene* fourthPtr = fourth.get();
     stack.switchScene(std::move(fourth));
+    EXPECT_EQ(stack.current(), thirdPtr);
+    stack.applyPending();
     EXPECT_EQ(stack.current(), fourthPtr);
 }
 


### PR DESCRIPTION
## Summary
- defer scene stack modifications using pending action queue
- apply queued transitions at frame end
- adapt tests to apply and verify pending actions

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68a93bdeba248327b4657b060219d0cf