### PR TITLE
test: cover TitleScene mouse click transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/boot_scene.hpp`/`src/boot_scene.cpp`: cena de boot que carrega recursos e vai para `TitleScene`.
 - `src/title_scene.hpp`/`src/title_scene.cpp`: menu de título com opção Start que abre `MapScene`.
 - Teste de fluxo de cenas Boot → Title → Map.
+- Teste de fluxo de cenas via clique do mouse em Start.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).

--- a/tests/scene_flow.cpp
+++ b/tests/scene_flow.cpp
@@ -23,5 +23,16 @@ TEST(SceneFlow, BootTitleMap) {
     EXPECT_NE(dynamic_cast<TitleScene*>(stack.current()), nullptr);
     stack.applyPending();
     EXPECT_NE(dynamic_cast<MapScene*>(stack.current()), nullptr);
+
+    stack.switchScene(std::make_unique<TitleScene>(stack));
+    stack.applyPending();
+    EXPECT_NE(dynamic_cast<TitleScene*>(stack.current()), nullptr);
+
+    const sf::Event click =
+        sf::Event::MouseButtonPressed{sf::Mouse::Button::Left, {210, 160}};
+    stack.current()->handleEvent(click);
+    EXPECT_NE(dynamic_cast<TitleScene*>(stack.current()), nullptr);
+    stack.applyPending();
+    EXPECT_NE(dynamic_cast<MapScene*>(stack.current()), nullptr);
 }
 


### PR DESCRIPTION
## Summary
- test mouse click on Start switches to MapScene
- note changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*
- `ctest --test-dir build/msvc` *(fails: no such directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a93e321eb88327b5b7438c412d42ea