### PR TITLE
fix(runtime): apply pending scenes before window closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).
 - Erro “Unsupported SFML component: system” (mudança para sintaxe do SFML 3).
 - Erro ao configurar por falta de `src/main.cpp`.
+- `src/main.cpp`: aplica `stack.applyPending()` logo após os eventos para garantir transições antes do fechamento da janela.
 ### Docs
 - Adicionado `VISION.md`.
 - Adicionado `ROADMAP.md`.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,6 +95,8 @@ int main() {
             }
         }
 
+        stack.applyPending();
+
         if (!window->isOpen()) {
             break;
         }
@@ -111,8 +113,6 @@ int main() {
         }
         // 3. Exibir o frame
         window->display();
-
-        stack.applyPending();
 
         // Completar o tempo de frame restante
         sf::Time workTime = frameClock.getElapsedTime();


### PR DESCRIPTION
## Summary
- call scene stack applyPending after event loop to ensure pending operations run before window closes
- document applyPending change in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Could not read presets from /workspace/lumy: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a93fa87f648327b9ddac81de50618f