### PR TITLE
test(scene): não atualizar após evento de fechamento

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/title_scene.hpp`/`src/title_scene.cpp`: menu de título com opção Start que abre `MapScene`.
 - Teste de fluxo de cenas Boot → Title → Map.
 - Teste de fluxo de cenas via clique do mouse em Start.
+- Teste para encerrar loop ao fechar a janela sem chamar `update`.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable(lumy-tests
   tests/basic_startup.cpp
   tests/scene_stack.cpp
   tests/scene_flow.cpp
+  tests/scene_loop_close.cpp
   src/scene.cpp
   src/scene_stack.cpp
   src/boot_scene.cpp

--- a/tests/scene_loop_close.cpp
+++ b/tests/scene_loop_close.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+#include <SFML/Graphics.hpp>
+
+#include "scene_stack.hpp"
+
+namespace {
+class CountingScene : public Scene {
+public:
+    int updates = 0;
+    void handleEvent(const sf::Event&) override {}
+    void update(float) override { ++updates; }
+    void draw(sf::RenderWindow&) const override {}
+};
+} // namespace
+
+TEST(SceneLoop, SkipUpdateAfterClose) {
+    sf::RenderWindow window(sf::VideoMode({100, 100}), "Test");
+    SceneStack stack;
+
+    auto scene = std::make_unique<CountingScene>();
+    CountingScene* scenePtr = scene.get();
+    stack.pushScene(std::move(scene));
+    stack.applyPending();
+
+    sf::Event event = sf::Event::Closed{};
+    if (event.is<sf::Event::Closed>()) {
+        window.close();
+    }
+    if (auto* current = stack.current()) {
+        current->handleEvent(event);
+    }
+
+    stack.applyPending();
+
+    if (window.isOpen()) {
+        if (auto* current = stack.current()) {
+            current->update(0.f);
+        }
+    }
+
+    EXPECT_FALSE(window.isOpen());
+    EXPECT_EQ(scenePtr->updates, 0);
+}
+


### PR DESCRIPTION
## Summary
- add regression test ensuring scene stack skips updates after window close
- wire new test into build and changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9409ff5188327aa73b536dd5358a4