### PR TITLE
feat: clamp deltaTime via helper and test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Teste de fluxo de cenas Boot → Title → Map.
 - Teste de fluxo de cenas via clique do mouse em Start.
 - Teste para encerrar loop ao fechar a janela sem chamar `update`.
+- `src/delta_time.hpp`/`src/delta_time.cpp`: função `clampDeltaTime` limita `deltaTime` e registra quedas de frame.
+- Teste unitário garantindo limitação de `deltaTime` para `maxDeltaTime`.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).
@@ -39,6 +41,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: encerra o loop quando a janela fecha e libera objetos alocados.
 - `src/main.cpp`: loop de eventos usa `pollEvent()` opcional, checa `Closed` com `event->is` e lê tecla Escape com `getIf`, repassando para a cena.
 - `src/main.cpp`: condiciona loop à janela aberta e verifica fechamento após eventos.
+- `src/main.cpp`: usa `clampDeltaTime` para restringir o intervalo de atualização.
 - `src/scene.cpp`: `handleEvent` usa ponteiro retornado por `getIf` para cliques do mouse.
 - `src/scene.hpp`/`src/scene.cpp`: `Scene` agora é abstrata e delega lógica à `MapScene`.
 - `src/main.cpp`: usa `SceneStack` para gerenciar cenas.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 # ===== Fontes do exemplo =====
 set(HELLO_TOWN_SOURCES
   src/main.cpp
+  src/delta_time.cpp
   src/scene.cpp
   src/scene_stack.cpp
   src/boot_scene.cpp
@@ -80,9 +81,11 @@ enable_testing()
 find_package(GTest CONFIG REQUIRED)
 add_executable(lumy-tests
   tests/basic_startup.cpp
+  tests/delta_time.cpp
   tests/scene_stack.cpp
   tests/scene_flow.cpp
   tests/scene_loop_close.cpp
+  src/delta_time.cpp
   src/scene.cpp
   src/scene_stack.cpp
   src/boot_scene.cpp

--- a/src/delta_time.cpp
+++ b/src/delta_time.cpp
@@ -1,0 +1,12 @@
+#include "delta_time.hpp"
+
+#include <iostream>
+
+float clampDeltaTime(float deltaTime, float maxDeltaTime) {
+    if (deltaTime > maxDeltaTime) {
+        std::cout << "[Frame drop] deltaTime: " << deltaTime << "s\n";
+        return maxDeltaTime;
+    }
+    return deltaTime;
+}
+

--- a/src/delta_time.hpp
+++ b/src/delta_time.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+// Retorna deltaTime limitado a maxDeltaTime.
+// Loga queda de frame quando deltaTime excede o limite.
+float clampDeltaTime(float deltaTime, float maxDeltaTime);
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include "boot_scene.hpp"
 #include "scene_stack.hpp"
+#include "delta_time.hpp"
 
 int main() {
     std::cout << "Lumy: hello-town iniciando...\n";
@@ -65,11 +66,7 @@ int main() {
 
     while (window->isOpen()) {
         sf::Time elapsed = frameClock.restart();
-        float deltaTime = elapsed.asSeconds();
-        if (deltaTime > maxDeltaTime) {
-            std::cout << "[Frame drop] deltaTime: " << deltaTime << "s\n";
-            deltaTime = maxDeltaTime;
-        }
+        float deltaTime = clampDeltaTime(elapsed.asSeconds(), maxDeltaTime);
 
         // Média de FPS a cada ~1 segundo
         fpsFrameCount++;

--- a/tests/delta_time.cpp
+++ b/tests/delta_time.cpp
@@ -1,0 +1,11 @@
+#include <gtest/gtest.h>
+
+#include "delta_time.hpp"
+
+TEST(DeltaTime, ClampsAboveMax) {
+    const float maxDeltaTime = 1.f / 30.f;
+    const float artificialDelta = 0.1f; // > maxDeltaTime
+    float clamped = clampDeltaTime(artificialDelta, maxDeltaTime);
+    EXPECT_FLOAT_EQ(clamped, maxDeltaTime);
+}
+


### PR DESCRIPTION
## Summary
- extract clampDeltaTime helper to cap frame delta and log drops
- add unit test verifying deltaTime values above 1/30s are clamped
- wire helper and test into build and document in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion)*
- `cmake --build build/msvc --config Debug` *(fails: directory not found)*
- `ctest --test-dir build/msvc` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a94e4277c08327b5d26ad692da16bc