### PR TITLE
fix(build): set test working directory and copy assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: fluxo de cenas Boot → Title → Map via `SceneStack`.
 - `src/main.cpp`: inicia `SceneStack` com `BootScene`.
 - `src/title_scene.cpp`: usa `openFromFile`, inicializa `startText` no construtor e verifica cliques com `sf::Vector2f`.
+- `CMakeLists.txt`: define diretório de trabalho dos testes e copia assets necessários.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,17 @@ add_executable(lumy-tests
 )
 target_link_libraries(lumy-tests PRIVATE GTest::gtest_main SFML::Graphics)
 target_include_directories(lumy-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
-add_test(NAME basic_startup COMMAND lumy-tests)
+set_property(TARGET lumy-tests PROPERTY RUNTIME_OUTPUT_DIRECTORY "${OUT_DIR}")
+if(EXISTS "${EXAMPLES_DIR}")
+  add_custom_command(TARGET lumy-tests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo "Copiando assets de ${EXAMPLES_DIR} para ${OUT_DIR}/game"
+    COMMAND ${CMAKE_COMMAND} -E rm -rf   "${OUT_DIR}/game"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}/game"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${EXAMPLES_DIR}" "${OUT_DIR}/game"
+    VERBATIM
+  )
+endif()
+add_test(NAME basic_startup COMMAND lumy-tests WORKING_DIRECTORY ${OUT_DIR})
 
 # ===== Instalação opcional =====
 include(GNUInstallDirs)


### PR DESCRIPTION
## Summary
- ensure lumy-tests run from binary output folder to access bundled assets
- copy example assets after building lumy-tests
- document test working directory change

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest --test-dir build/msvc` *(fails: Failed to change working directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a51ec1f48327abdabcdb6e6cdd30