### PR TITLE
docs: clarify ctest usage and CDash config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Teste unitário garantindo limitação de `deltaTime` para `maxDeltaTime`.
 - `tests/title_scene.cpp`: testa exceção ao faltar `game/font.ttf`.
 - `game/font.ttf`: fonte padrão para `TitleScene`.
+- `DartConfiguration.tcl` com configuração básica para envios ao CDash.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).
@@ -71,6 +72,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: comentários explicando a sequência de renderização (limpar → desenhar → exibir).
 - `docs/scene_flow.md` e `README.md`: fluxo Boot → Title → Map e uso do `SceneStack`.
 - `docs/scene_flow.md` e `README.md`: documentada exceção ao falhar carregamento da fonte.
+- `contributing.md`: instruções para rodar testes com `ctest --output-on-failure -R <regex>` sem `-T test`.
 
 
 

--- a/DartConfiguration.tcl
+++ b/DartConfiguration.tcl
@@ -1,0 +1,15 @@
+# CTest/CDash configuration for Lumy
+# Adjust values as needed for your environment.
+
+set(CTEST_SITE "local")
+set(CTEST_BUILD_NAME "msvc-vcpkg")
+set(CTEST_SOURCE_DIRECTORY ".")
+set(CTEST_BINARY_DIRECTORY "build/msvc")
+set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
+set(CTEST_CONFIGURATION_TYPE "Debug")
+
+# CDash submission
+set(CTEST_DROP_METHOD "https")
+set(CTEST_DROP_SITE "cdash.example.com")
+set(CTEST_DROP_LOCATION "/submit.php?project=Lumy")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/contributing.md
+++ b/contributing.md
@@ -30,6 +30,16 @@ Este guia explica como propor ideias, reportar bugs e enviar PRs de forma eficie
 6. **Atualize o CHANGELOG** (seção **[Unreleased]**).
 7. **Abra o PR** linkando a issue e marcando o checklist.
 
+## Rodando testes
+Após compilar, execute os testes com:
+
+```sh
+ctest --output-on-failure -R <regex>
+```
+
+Use `<regex>` para filtrar pelos nomes desejados.
+A opção `-T test` não é mais necessária.
+
 ## Padrão de commits
 Use mensagens descritivas e no imperativo. Você pode seguir *Conventional Commits* (opcional), por exemplo:
 - `feat(events): adiciona ShowChoice com 2–4 opções`


### PR DESCRIPTION
## Summary
- document running tests with `ctest --output-on-failure -R <regex>`
- add optional `DartConfiguration.tcl` for CDash submissions

## Testing
- `ctest --output-on-failure -R .`

------
https://chatgpt.com/codex/tasks/task_e_68a9ac14c81c8327aa641e32c7fc675d