### PR TITLE
test: resolve TitleScene test working directory relative to source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `CMakeLists.txt`: define diretório de trabalho dos testes e copia assets necessários.
 - `src/title_scene.cpp`: verifica carregamento da fonte e lança exceção se falhar.
 - `src/title_scene.cpp`: trata tecla Enter usando `event.is`.
+- `tests/title_scene.cpp`: define diretório de trabalho relativo ao arquivo de teste.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/tests/title_scene.cpp
+++ b/tests/title_scene.cpp
@@ -7,7 +7,8 @@
 
 TEST(TitleScene, MissingFontThrows) {
     auto old = std::filesystem::current_path();
-    std::filesystem::current_path(old / "tests");
+    auto testsDir = std::filesystem::path{__FILE__}.parent_path();
+    std::filesystem::current_path(testsDir);
     SceneStack stack;
     EXPECT_THROW(TitleScene{stack}, std::runtime_error);
     std::filesystem::current_path(old);


### PR DESCRIPTION
## Summary
- derive tests directory from `__FILE__` in `TitleScene.MissingFontThrows`
- note change in changelog

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML" with any of the following names: SFMLConfig.cmake, sfml-config.cmake)*
- `ctest --test-dir build --output-on-failure -R TitleScene.MissingFontThrows` *(No tests were found!!!)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bea1e0f88327a357e6ef12c20f25