### PR TITLE
fix(runtime): use getIf for Enter key handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/title_scene.cpp`: usa `openFromFile`, inicializa `startText` no construtor e verifica cliques com `sf::Vector2f`.
 - `CMakeLists.txt`: define diretório de trabalho dos testes e copia assets necessários.
 - `src/title_scene.cpp`: verifica carregamento da fonte e lança exceção se falhar.
-- `src/title_scene.cpp`: trata tecla Enter usando `event.is`.
+- `src/title_scene.cpp`: trata tecla Enter usando ponteiro retornado por `getIf`.
 - `tests/title_scene.cpp`: define diretório de trabalho relativo ao arquivo de teste.
 
 ### Fixed

--- a/src/title_scene.cpp
+++ b/src/title_scene.cpp
@@ -12,8 +12,8 @@ TitleScene::TitleScene(SceneStack& stack)
 }
 
 void TitleScene::handleEvent(const sf::Event& event) {
-    if (event.is<sf::Event::KeyPressed>() &&
-        event.get<sf::Event::KeyPressed>().code == sf::Keyboard::Key::Enter) {
+    if (const auto* key = event.getIf<sf::Event::KeyPressed>();
+        key && key->code == sf::Keyboard::Key::Enter) {
         stack_.switchScene(std::make_unique<MapScene>(sf::Vector2f{320.f, 180.f}));
     }
 }


### PR DESCRIPTION
## Summary
- handle TitleScene Enter key using event.getIf pointer
- document pointer-based key handling in changelog

## Testing
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest --test-dir build/msvc --build-config Debug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c0c1b9248327adc7933a3563e68e