### PR TITLE
feat: add TMX map loader and renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/scene_stack.hpp` e `src/scene_stack.cpp`: pilha de cenas com push/pop/switch.
 - Testes para `SceneStack`.
 - `src/map_scene.hpp` e `src/map_scene.cpp`: classe `MapScene` com lógica do herói.
+- `src/map.hpp`/`src/map.cpp`: classe `Map` para carregar e desenhar TMX.
 - `src/boot_scene.hpp`/`src/boot_scene.cpp`: cena de boot que carrega recursos e vai para `TitleScene`.
 - `src/title_scene.hpp`/`src/title_scene.cpp`: menu de título com opção Start que abre `MapScene`.
 - Teste de fluxo de cenas Boot → Title → Map.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(HELLO_TOWN_SOURCES
   src/boot_scene.cpp
   src/title_scene.cpp
   src/map_scene.cpp
+  src/map.cpp
 )
 
 add_executable(hello-town ${HELLO_TOWN_SOURCES})
@@ -92,6 +93,7 @@ add_executable(lumy-tests
   src/boot_scene.cpp
   src/title_scene.cpp
   src/map_scene.cpp
+  src/map.cpp
 )
 target_link_libraries(lumy-tests PRIVATE GTest::gtest_main SFML::Graphics)
 target_include_directories(lumy-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1,0 +1,155 @@
+#include "map.hpp"
+
+#include <tmxlite/Map.hpp>
+#include <tmxlite/Tileset.hpp>
+#include <tmxlite/Layer.hpp>
+#include <tmxlite/TileLayer.hpp>
+
+#include <SFML/Graphics/Vertex.hpp>
+
+#include <filesystem>
+#include <iostream>
+#include <unordered_map>
+#include <algorithm>
+
+bool Map::load(const std::string& path) {
+    tmx::Map tmxMap;
+    if (!tmxMap.load(path)) {
+        std::cerr << "Failed to load TMX: " << path << '\n';
+        return false;
+    }
+
+    const auto tileCount = tmxMap.getTileCount();
+    std::cout << "TMX loaded: " << tileCount.x << "x" << tileCount.y
+              << " tiles, layers: " << tmxMap.getLayers().size() << '\n';
+
+    tilesetTextures_.clear();
+    layers_.clear();
+
+    std::filesystem::path base = std::filesystem::path(path).parent_path();
+
+    struct TilesetInfo {
+        int firstGid{};
+        sf::Vector2u tileSize;
+        unsigned columns{};
+        const sf::Texture* texture{};
+    };
+    std::vector<TilesetInfo> tilesets;
+
+    for (const auto& ts : tmxMap.getTilesets()) {
+        sf::Texture tex;
+        auto texPath = base / ts.getImagePath();
+        if (!tex.loadFromFile(texPath.string())) {
+            std::cerr << "Failed to load tileset texture: " << texPath << '\n';
+            return false;
+        }
+        int first = static_cast<int>(ts.getFirstGID());
+        auto [it, inserted] = tilesetTextures_.emplace(first, std::move(tex));
+        TilesetInfo info;
+        info.firstGid = first;
+        info.tileSize = {ts.getTileSize().x, ts.getTileSize().y};
+        info.columns = ts.getColumnCount();
+        info.texture = &it->second;
+        tilesets.push_back(info);
+
+        // store properties for future use
+        for (const auto& prop : ts.getProperties()) {
+            (void)prop;
+        }
+    }
+
+    std::sort(tilesets.begin(), tilesets.end(),
+              [](const TilesetInfo& a, const TilesetInfo& b) {
+                  return a.firstGid < b.firstGid;
+              });
+
+    for (const auto& layer : tmxMap.getLayers()) {
+        if (layer->getType() != tmx::Layer::Type::Tile)
+            continue;
+
+        const auto& tileLayer = layer->getLayerAs<tmx::TileLayer>();
+
+        for (const auto& prop : layer->getProperties()) {
+            (void)prop;
+        }
+
+        std::unordered_map<const sf::Texture*, sf::VertexArray> batches;
+        const auto& tiles = tileLayer.getTiles();
+        sf::Vector2u tileSizePx = tmxMap.getTileSize();
+
+        for (std::size_t i = 0; i < tiles.size(); ++i) {
+            const auto& tile = tiles[i];
+            if (tile.ID == 0)
+                continue;
+
+            const TilesetInfo* tsInfo = nullptr;
+            for (const auto& info : tilesets) {
+                if (tile.ID >= static_cast<std::uint32_t>(info.firstGid))
+                    tsInfo = &info;
+                else
+                    break;
+            }
+            if (!tsInfo)
+                continue;
+
+            sf::VertexArray& va = batches[tsInfo->texture];
+            va.setPrimitiveType(sf::Quads);
+
+            std::uint32_t localID = tile.ID - tsInfo->firstGid;
+            unsigned tu = localID % tsInfo->columns;
+            unsigned tv = localID / tsInfo->columns;
+            float tx = static_cast<float>(tu * tsInfo->tileSize.x);
+            float ty = static_cast<float>(tv * tsInfo->tileSize.y);
+
+            unsigned x = static_cast<unsigned>(i % tileCount.x);
+            unsigned y = static_cast<unsigned>(i / tileCount.x);
+            sf::Vertex quad[4];
+            quad[0].position = {static_cast<float>(x * tileSizePx.x),
+                                static_cast<float>(y * tileSizePx.y)};
+            quad[1].position = {static_cast<float>((x + 1) * tileSizePx.x),
+                                static_cast<float>(y * tileSizePx.y)};
+            quad[2].position = {static_cast<float>((x + 1) * tileSizePx.x),
+                                static_cast<float>((y + 1) * tileSizePx.y)};
+            quad[3].position = {static_cast<float>(x * tileSizePx.x),
+                                static_cast<float>((y + 1) * tileSizePx.y)};
+
+            sf::Vector2f uv[4] = {{tx, ty},
+                                  {tx + tsInfo->tileSize.x, ty},
+                                  {tx + tsInfo->tileSize.x, ty + tsInfo->tileSize.y},
+                                  {tx, ty + tsInfo->tileSize.y}};
+
+            std::uint8_t flip = tile.flipFlags;
+            if (flip & tmx::TileLayer::FlipFlag::Horizontal) {
+                std::swap(uv[0], uv[1]);
+                std::swap(uv[3], uv[2]);
+            }
+            if (flip & tmx::TileLayer::FlipFlag::Vertical) {
+                std::swap(uv[0], uv[3]);
+                std::swap(uv[1], uv[2]);
+            }
+            if (flip & tmx::TileLayer::FlipFlag::Diagonal) {
+                std::swap(uv[1], uv[3]);
+            }
+
+            for (int v = 0; v < 4; ++v) {
+                quad[v].texCoords = uv[v];
+                va.append(quad[v]);
+            }
+        }
+
+        for (auto& [texPtr, vertices] : batches) {
+            layers_.push_back({texPtr, std::move(vertices)});
+        }
+    }
+
+    return true;
+}
+
+void Map::draw(sf::RenderTarget& target) const {
+    for (const auto& layer : layers_) {
+        sf::RenderStates states;
+        states.texture = layer.texture;
+        target.draw(layer.vertices, states);
+    }
+}
+

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/VertexArray.hpp>
+
+#include <unordered_map>
+#include <vector>
+#include <string>
+
+class Map {
+public:
+    // Loads a TMX map from the given path. Returns true on success.
+    bool load(const std::string& path);
+
+    // Draws all loaded layers to the given render target.
+    void draw(sf::RenderTarget& target) const;
+
+private:
+    struct Layer {
+        const sf::Texture* texture{};
+        sf::VertexArray vertices;
+    };
+
+    std::unordered_map<int, sf::Texture> tilesetTextures_;
+    std::vector<Layer> layers_;
+};
+


### PR DESCRIPTION
## Summary
- load TMX maps using tmxlite and build vertex arrays per tileset
- expose Map::draw for rendering
- wire new files into CMake build and changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*
- `ctest --test-dir build/msvc --output-on-failure` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cdd8188c83279641df639f19fa45