### PR TITLE
feat(runtime): add texture manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `tests/title_scene.cpp`: testa exceção ao faltar `game/font.ttf`.
 - `game/font.ttf`: fonte padrão para `TitleScene`.
 - `DartConfiguration.tcl` com configuração básica para envios ao CDash.
+- `src/texture_manager.hpp`/`src/texture_manager.cpp`: cache simples de texturas.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HELLO_TOWN_SOURCES
   src/title_scene.cpp
   src/map_scene.cpp
   src/map.cpp
+  src/texture_manager.cpp
 )
 
 add_executable(hello-town ${HELLO_TOWN_SOURCES})
@@ -94,6 +95,7 @@ add_executable(lumy-tests
   src/title_scene.cpp
   src/map_scene.cpp
   src/map.cpp
+  src/texture_manager.cpp
 )
 target_link_libraries(lumy-tests PRIVATE GTest::gtest_main SFML::Graphics)
 target_include_directories(lumy-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/src/texture_manager.cpp
+++ b/src/texture_manager.cpp
@@ -1,0 +1,26 @@
+#include "texture_manager.hpp"
+
+#include <stdexcept>
+
+const sf::Texture& TextureManager::acquire(const std::filesystem::path& path) {
+    auto normalized = std::filesystem::weakly_canonical(path);
+    std::string key = normalized.generic_string();
+
+    auto it = textures_.find(key);
+    if (it != textures_.end()) {
+        return it->second;
+    }
+
+    sf::Texture texture;
+    if (!texture.loadFromFile(key)) {
+        throw std::runtime_error("Failed to load texture: " + key);
+    }
+
+    auto [insertIt, inserted] = textures_.emplace(std::move(key), std::move(texture));
+    return insertIt->second;
+}
+
+void TextureManager::clear() {
+    textures_.clear();
+}
+

--- a/src/texture_manager.hpp
+++ b/src/texture_manager.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <SFML/Graphics/Texture.hpp>
+
+#include <unordered_map>
+#include <string>
+#include <filesystem>
+
+// Manages loading and caching of textures.
+class TextureManager {
+public:
+    // Returns a reference to the texture located at the given path.
+    // Loads the texture from disk if it isn't already cached.
+    const sf::Texture& acquire(const std::filesystem::path& path);
+
+    // Clears all cached textures.
+    void clear();
+
+private:
+    std::unordered_map<std::string, sf::Texture> textures_;
+};
+


### PR DESCRIPTION
## Summary
- cache textures by path with new TextureManager
- build system compiles texture manager

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest --test-dir build/msvc -C Debug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e178364883278782b810d525deb0