### PR TITLE
refactor: use TextureManager for map tileset textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/title_scene.cpp`: trata tecla Enter usando ponteiro retornado por `getIf`.
 - `src/boot_scene.*`: carrega e desenha o mapa `game/first.tmx` ao iniciar.
 - `tests/title_scene.cpp`: define diretório de trabalho relativo ao arquivo de teste.
+- `src/map.hpp`/`src/map.cpp`: `Map` usa `TextureManager` e armazena ponteiros para texturas de tileset.
+- `src/boot_scene.hpp`/`src/boot_scene.cpp`: `BootScene` gerencia `TextureManager` e o fornece ao `Map`.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/boot_scene.cpp
+++ b/src/boot_scene.cpp
@@ -1,7 +1,8 @@
 #include "boot_scene.hpp"
 #include <iostream>
 
-BootScene::BootScene(SceneStack& stack) : stack_(stack) {
+BootScene::BootScene(SceneStack& stack)
+    : stack_(stack), textures_(), map_(textures_) {
     map_.load("game/first.tmx");
 }
 

--- a/src/boot_scene.hpp
+++ b/src/boot_scene.hpp
@@ -3,6 +3,7 @@
 #include "scene.hpp"
 #include "scene_stack.hpp"
 #include "map.hpp"
+#include "texture_manager.hpp"
 
 class BootScene : public Scene {
 public:
@@ -14,6 +15,7 @@ public:
 
 private:
     SceneStack& stack_;
+    TextureManager textures_;
     Map map_;
     bool loaded_ = false;
 };

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -12,6 +12,8 @@
 #include <unordered_map>
 #include <algorithm>
 
+Map::Map(TextureManager& textures) : textures_(textures) {}
+
 bool Map::load(const std::string& path) {
     tmx::Map tmxMap;
     if (!tmxMap.load(path)) {
@@ -37,19 +39,15 @@ bool Map::load(const std::string& path) {
     std::vector<TilesetInfo> tilesets;
 
     for (const auto& ts : tmxMap.getTilesets()) {
-        sf::Texture tex;
         auto texPath = base / ts.getImagePath();
-        if (!tex.loadFromFile(texPath.string())) {
-            std::cerr << "Failed to load tileset texture: " << texPath << '\n';
-            return false;
-        }
+        const sf::Texture& tex = textures_.acquire(texPath);
         int first = static_cast<int>(ts.getFirstGID());
-        auto [it, inserted] = tilesetTextures_.emplace(first, std::move(tex));
+        tilesetTextures_.emplace(first, &tex);
         TilesetInfo info;
         info.firstGid = first;
         info.tileSize = {ts.getTileSize().x, ts.getTileSize().y};
         info.columns = ts.getColumnCount();
-        info.texture = &it->second;
+        info.texture = &tex;
         tilesets.push_back(info);
 
         // store properties for future use

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -8,8 +8,12 @@
 #include <vector>
 #include <string>
 
+#include "texture_manager.hpp"
+
 class Map {
 public:
+    explicit Map(TextureManager& textures);
+
     // Loads a TMX map from the given path. Returns true on success.
     bool load(const std::string& path);
 
@@ -22,7 +26,8 @@ private:
         sf::VertexArray vertices;
     };
 
-    std::unordered_map<int, sf::Texture> tilesetTextures_;
+    TextureManager& textures_;
+    std::unordered_map<int, const sf::Texture*> tilesetTextures_;
     std::vector<Layer> layers_;
 };
 


### PR DESCRIPTION
## Summary
- Map stores tileset textures as pointers acquired from TextureManager
- BootScene owns a TextureManager and passes it to Map

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e29386d883278c976908419093b9