### PR TITLE
refactor(runtime): share texture manager across scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/boot_scene.*`: carrega e desenha o mapa `game/first.tmx` ao iniciar.
 - `tests/title_scene.cpp`: define diretório de trabalho relativo ao arquivo de teste.
 - `src/map.hpp`/`src/map.cpp`: `Map` usa `TextureManager` e armazena ponteiros para texturas de tileset.
-- `src/boot_scene.hpp`/`src/boot_scene.cpp`: `BootScene` gerencia `TextureManager` e o fornece ao `Map`.
+- `src/main.cpp`/`src/boot_scene.*`: `TextureManager` global passado por referência ao `Map`.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/docs/scene_flow.md
+++ b/docs/scene_flow.md
@@ -16,8 +16,9 @@ Este documento descreve o fluxo de cenas do exemplo `hello-town` e como usar o `
 ## Uso básico de `SceneStack`
 
 ```cpp
+TextureManager textures;
 SceneStack stack;
-stack.pushScene(std::make_unique<BootScene>(stack));
+stack.pushScene(std::make_unique<BootScene>(stack, textures));
 
 while (window.isOpen()) {
     while (auto event = window.pollEvent()) {

--- a/src/boot_scene.cpp
+++ b/src/boot_scene.cpp
@@ -1,8 +1,8 @@
 #include "boot_scene.hpp"
 #include <iostream>
 
-BootScene::BootScene(SceneStack& stack)
-    : stack_(stack), textures_(), map_(textures_) {
+BootScene::BootScene(SceneStack& stack, TextureManager& textures)
+    : stack_(stack), textures_(textures), map_(textures_) {
     map_.load("game/first.tmx");
 }
 

--- a/src/boot_scene.hpp
+++ b/src/boot_scene.hpp
@@ -7,7 +7,7 @@
 
 class BootScene : public Scene {
 public:
-    explicit BootScene(SceneStack& stack);
+    BootScene(SceneStack& stack, TextureManager& textures);
 
     void handleEvent(const sf::Event& event) override;
     void update(float deltaTime) override;
@@ -15,7 +15,7 @@ public:
 
 private:
     SceneStack& stack_;
-    TextureManager textures_;
+    TextureManager& textures_;
     Map map_;
     bool loaded_ = false;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "boot_scene.hpp"
 #include "scene_stack.hpp"
 #include "delta_time.hpp"
+#include "texture_manager.hpp"
 
 int main() {
     std::cout << "Lumy: hello-town iniciando...\n";
@@ -60,8 +61,9 @@ int main() {
     const float maxDeltaTime = 1.f / 30.f;
 
     // Pilha de cenas: inicia em BootScene
+    TextureManager textures;
     SceneStack stack;
-    auto bootScene = std::make_unique<BootScene>(stack);
+    auto bootScene = std::make_unique<BootScene>(stack, textures);
     stack.pushScene(std::move(bootScene));
 
     while (window->isOpen()) {

--- a/tests/scene_flow.cpp
+++ b/tests/scene_flow.cpp
@@ -5,10 +5,12 @@
 #include "map_scene.hpp"
 #include "scene_stack.hpp"
 #include "title_scene.hpp"
+#include "texture_manager.hpp"
 
 TEST(SceneFlow, BootTitleMap) {
+    TextureManager textures;
     SceneStack stack;
-    stack.pushScene(std::make_unique<BootScene>(stack));
+    stack.pushScene(std::make_unique<BootScene>(stack, textures));
     EXPECT_EQ(stack.current(), nullptr);
     stack.applyPending();
     EXPECT_NE(dynamic_cast<BootScene*>(stack.current()), nullptr);


### PR DESCRIPTION
## Summary
- create a shared TextureManager in main and pass it to scenes
- adjust BootScene and tests to receive a TextureManager reference
- update docs and changelog for the new initialization

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest --test-dir build/msvc -C Debug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e3aadcdc8327a9411a69a76fb70f