### PR TITLE
docs: document tileset texture cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `game/font.ttf`: fonte padrão para `TitleScene`.
 - `DartConfiguration.tcl` com configuração básica para envios ao CDash.
 - `src/texture_manager.hpp`/`src/texture_manager.cpp`: cache simples de texturas.
+- Cache de texturas de tileset via `TextureManager`, evitando carregamentos duplicados.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ No VS Code, selecione os mesmos presets e depure o alvo `hello-town` com `F5`.
 O exemplo `hello-town` usa `SceneStack` com as cenas Boot → Title → Map. `BootScene` carrega recursos e muda para `TitleScene`, que exibe "Start" (requer `game/font.ttf`; falha no carregamento lança exceção) e ao confirmar abre `MapScene` com um herói movido por W/A/S/D.
 
 Veja [docs/scene_flow.md](docs/scene_flow.md) para detalhes.
+
+## Gerenciamento de texturas
+
+O `TextureManager` centraliza o carregamento de tilesets e reutiliza texturas já abertas, evitando carregamentos duplicados e reduzindo uso de memória.

--- a/docs/scene_flow.md
+++ b/docs/scene_flow.md
@@ -34,5 +34,7 @@ while (window.isOpen()) {
 }
 ```
 
+O `TextureManager` funciona como um cache de texturas: ao carregar tilesets, ele reutiliza instâncias já carregadas e evita duplicar arquivos na memória.
+
 O `SceneStack` mantém apenas a cena ativa no topo e permite `pushScene`, `popScene` e `switchScene` para transições simples.
 


### PR DESCRIPTION
## Summary
- add changelog entry for tileset texture cache
- explain TextureManager cache in docs and README to avoid duplicate tilesets

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest --test-dir build/msvc -C Debug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e518bf5c832783ffc8bd2fd90aa4