### PR TITLE
refactor: explicitly construct tile size vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/boot_scene.*`: carrega e desenha o mapa `game/first.tmx` ao iniciar.
 - `tests/title_scene.cpp`: define diretório de trabalho relativo ao arquivo de teste.
 - `src/map.hpp`/`src/map.cpp`: `Map` usa `TextureManager` e armazena ponteiros para texturas de tileset.
+- `src/map.cpp`: constrói `sf::Vector2u` de tamanho do tile explicitamente para evitar conversão implícita.
 - `src/main.cpp`/`src/boot_scene.*`: `TextureManager` global passado por referência ao `Map`.
 
 ### Fixed

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -73,7 +73,8 @@ bool Map::load(const std::string& path) {
 
         std::unordered_map<const sf::Texture*, sf::VertexArray> batches;
         const auto& tiles = tileLayer.getTiles();
-        sf::Vector2u tileSizePx = tmxMap.getTileSize();
+        const auto tmxTileSize = tmxMap.getTileSize();
+        sf::Vector2u tileSizePx{tmxTileSize.x, tmxTileSize.y};
 
         for (std::size_t i = 0; i < tiles.size(); ++i) {
             const auto& tile = tiles[i];


### PR DESCRIPTION
## Summary
- build sf::Vector2u tile size using explicit members
- document tile size vector construction in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Could not read presets from /workspace/lumy: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ead54a408327be56a8f4b22d926a