### PR TITLE
refactor: render tiles with triangle primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/map.hpp`/`src/map.cpp`: `Map` usa `TextureManager` e armazena ponteiros para texturas de tileset.
 - `src/map.cpp`: constrói `sf::Vector2u` de tamanho do tile explicitamente para evitar conversão implícita.
 - `src/main.cpp`/`src/boot_scene.*`: `TextureManager` global passado por referência ao `Map`.
+- `src/map.cpp`: substitui `sf::Quads` por `sf::PrimitiveType::Triangles` para desenhar tiles.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1,154 +1,159 @@
 #include "map.hpp"
 
-#include <tmxlite/Map.hpp>
-#include <tmxlite/Tileset.hpp>
 #include <tmxlite/Layer.hpp>
+#include <tmxlite/Map.hpp>
 #include <tmxlite/TileLayer.hpp>
+#include <tmxlite/Tileset.hpp>
 
 #include <SFML/Graphics/Vertex.hpp>
 
+#include <algorithm>
 #include <filesystem>
 #include <iostream>
 #include <unordered_map>
-#include <algorithm>
 
-Map::Map(TextureManager& textures) : textures_(textures) {}
+Map::Map(TextureManager &textures) : textures_(textures) {}
 
-bool Map::load(const std::string& path) {
-    tmx::Map tmxMap;
-    if (!tmxMap.load(path)) {
-        std::cerr << "Failed to load TMX: " << path << '\n';
-        return false;
+bool Map::load(const std::string &path) {
+  tmx::Map tmxMap;
+  if (!tmxMap.load(path)) {
+    std::cerr << "Failed to load TMX: " << path << '\n';
+    return false;
+  }
+
+  const auto tileCount = tmxMap.getTileCount();
+  std::cout << "TMX loaded: " << tileCount.x << "x" << tileCount.y
+            << " tiles, layers: " << tmxMap.getLayers().size() << '\n';
+
+  tilesetTextures_.clear();
+  layers_.clear();
+
+  std::filesystem::path base = std::filesystem::path(path).parent_path();
+
+  struct TilesetInfo {
+    int firstGid{};
+    sf::Vector2u tileSize;
+    unsigned columns{};
+    const sf::Texture *texture{};
+  };
+  std::vector<TilesetInfo> tilesets;
+
+  for (const auto &ts : tmxMap.getTilesets()) {
+    auto texPath = base / ts.getImagePath();
+    const sf::Texture &tex = textures_.acquire(texPath);
+    int first = static_cast<int>(ts.getFirstGID());
+    tilesetTextures_.emplace(first, &tex);
+    TilesetInfo info;
+    info.firstGid = first;
+    info.tileSize = {ts.getTileSize().x, ts.getTileSize().y};
+    info.columns = ts.getColumnCount();
+    info.texture = &tex;
+    tilesets.push_back(info);
+
+    // store properties for future use
+    for (const auto &prop : ts.getProperties()) {
+      (void)prop;
+    }
+  }
+
+  std::sort(tilesets.begin(), tilesets.end(),
+            [](const TilesetInfo &a, const TilesetInfo &b) {
+              return a.firstGid < b.firstGid;
+            });
+
+  for (const auto &layer : tmxMap.getLayers()) {
+    if (layer->getType() != tmx::Layer::Type::Tile)
+      continue;
+
+    const auto &tileLayer = layer->getLayerAs<tmx::TileLayer>();
+
+    for (const auto &prop : layer->getProperties()) {
+      (void)prop;
     }
 
-    const auto tileCount = tmxMap.getTileCount();
-    std::cout << "TMX loaded: " << tileCount.x << "x" << tileCount.y
-              << " tiles, layers: " << tmxMap.getLayers().size() << '\n';
+    std::unordered_map<const sf::Texture *, sf::VertexArray> batches;
+    const auto &tiles = tileLayer.getTiles();
+    const auto tmxTileSize = tmxMap.getTileSize();
+    sf::Vector2u tileSizePx{tmxTileSize.x, tmxTileSize.y};
 
-    tilesetTextures_.clear();
-    layers_.clear();
+    for (std::size_t i = 0; i < tiles.size(); ++i) {
+      const auto &tile = tiles[i];
+      if (tile.ID == 0)
+        continue;
 
-    std::filesystem::path base = std::filesystem::path(path).parent_path();
+      const TilesetInfo *tsInfo = nullptr;
+      for (const auto &info : tilesets) {
+        if (tile.ID >= static_cast<std::uint32_t>(info.firstGid))
+          tsInfo = &info;
+        else
+          break;
+      }
+      if (!tsInfo)
+        continue;
 
-    struct TilesetInfo {
-        int firstGid{};
-        sf::Vector2u tileSize;
-        unsigned columns{};
-        const sf::Texture* texture{};
-    };
-    std::vector<TilesetInfo> tilesets;
+      sf::VertexArray &va = batches[tsInfo->texture];
+      va.setPrimitiveType(sf::PrimitiveType::Triangles);
 
-    for (const auto& ts : tmxMap.getTilesets()) {
-        auto texPath = base / ts.getImagePath();
-        const sf::Texture& tex = textures_.acquire(texPath);
-        int first = static_cast<int>(ts.getFirstGID());
-        tilesetTextures_.emplace(first, &tex);
-        TilesetInfo info;
-        info.firstGid = first;
-        info.tileSize = {ts.getTileSize().x, ts.getTileSize().y};
-        info.columns = ts.getColumnCount();
-        info.texture = &tex;
-        tilesets.push_back(info);
+      std::uint32_t localID = tile.ID - tsInfo->firstGid;
+      unsigned tu = localID % tsInfo->columns;
+      unsigned tv = localID / tsInfo->columns;
+      float tx = static_cast<float>(tu * tsInfo->tileSize.x);
+      float ty = static_cast<float>(tv * tsInfo->tileSize.y);
 
-        // store properties for future use
-        for (const auto& prop : ts.getProperties()) {
-            (void)prop;
-        }
+      unsigned x = static_cast<unsigned>(i % tileCount.x);
+      unsigned y = static_cast<unsigned>(i / tileCount.x);
+      sf::Vertex quad[4];
+      quad[0].position = {static_cast<float>(x * tileSizePx.x),
+                          static_cast<float>(y * tileSizePx.y)};
+      quad[1].position = {static_cast<float>((x + 1) * tileSizePx.x),
+                          static_cast<float>(y * tileSizePx.y)};
+      quad[2].position = {static_cast<float>((x + 1) * tileSizePx.x),
+                          static_cast<float>((y + 1) * tileSizePx.y)};
+      quad[3].position = {static_cast<float>(x * tileSizePx.x),
+                          static_cast<float>((y + 1) * tileSizePx.y)};
+
+      sf::Vector2f uv[4] = {{tx, ty},
+                            {tx + tsInfo->tileSize.x, ty},
+                            {tx + tsInfo->tileSize.x, ty + tsInfo->tileSize.y},
+                            {tx, ty + tsInfo->tileSize.y}};
+
+      std::uint8_t flip = tile.flipFlags;
+      if (flip & tmx::TileLayer::FlipFlag::Horizontal) {
+        std::swap(uv[0], uv[1]);
+        std::swap(uv[3], uv[2]);
+      }
+      if (flip & tmx::TileLayer::FlipFlag::Vertical) {
+        std::swap(uv[0], uv[3]);
+        std::swap(uv[1], uv[2]);
+      }
+      if (flip & tmx::TileLayer::FlipFlag::Diagonal) {
+        std::swap(uv[1], uv[3]);
+      }
+
+      for (int v = 0; v < 4; ++v) {
+        quad[v].texCoords = uv[v];
+      }
+
+      va.append(quad[0]);
+      va.append(quad[1]);
+      va.append(quad[2]);
+      va.append(quad[0]);
+      va.append(quad[2]);
+      va.append(quad[3]);
     }
 
-    std::sort(tilesets.begin(), tilesets.end(),
-              [](const TilesetInfo& a, const TilesetInfo& b) {
-                  return a.firstGid < b.firstGid;
-              });
-
-    for (const auto& layer : tmxMap.getLayers()) {
-        if (layer->getType() != tmx::Layer::Type::Tile)
-            continue;
-
-        const auto& tileLayer = layer->getLayerAs<tmx::TileLayer>();
-
-        for (const auto& prop : layer->getProperties()) {
-            (void)prop;
-        }
-
-        std::unordered_map<const sf::Texture*, sf::VertexArray> batches;
-        const auto& tiles = tileLayer.getTiles();
-        const auto tmxTileSize = tmxMap.getTileSize();
-        sf::Vector2u tileSizePx{tmxTileSize.x, tmxTileSize.y};
-
-        for (std::size_t i = 0; i < tiles.size(); ++i) {
-            const auto& tile = tiles[i];
-            if (tile.ID == 0)
-                continue;
-
-            const TilesetInfo* tsInfo = nullptr;
-            for (const auto& info : tilesets) {
-                if (tile.ID >= static_cast<std::uint32_t>(info.firstGid))
-                    tsInfo = &info;
-                else
-                    break;
-            }
-            if (!tsInfo)
-                continue;
-
-            sf::VertexArray& va = batches[tsInfo->texture];
-            va.setPrimitiveType(sf::Quads);
-
-            std::uint32_t localID = tile.ID - tsInfo->firstGid;
-            unsigned tu = localID % tsInfo->columns;
-            unsigned tv = localID / tsInfo->columns;
-            float tx = static_cast<float>(tu * tsInfo->tileSize.x);
-            float ty = static_cast<float>(tv * tsInfo->tileSize.y);
-
-            unsigned x = static_cast<unsigned>(i % tileCount.x);
-            unsigned y = static_cast<unsigned>(i / tileCount.x);
-            sf::Vertex quad[4];
-            quad[0].position = {static_cast<float>(x * tileSizePx.x),
-                                static_cast<float>(y * tileSizePx.y)};
-            quad[1].position = {static_cast<float>((x + 1) * tileSizePx.x),
-                                static_cast<float>(y * tileSizePx.y)};
-            quad[2].position = {static_cast<float>((x + 1) * tileSizePx.x),
-                                static_cast<float>((y + 1) * tileSizePx.y)};
-            quad[3].position = {static_cast<float>(x * tileSizePx.x),
-                                static_cast<float>((y + 1) * tileSizePx.y)};
-
-            sf::Vector2f uv[4] = {{tx, ty},
-                                  {tx + tsInfo->tileSize.x, ty},
-                                  {tx + tsInfo->tileSize.x, ty + tsInfo->tileSize.y},
-                                  {tx, ty + tsInfo->tileSize.y}};
-
-            std::uint8_t flip = tile.flipFlags;
-            if (flip & tmx::TileLayer::FlipFlag::Horizontal) {
-                std::swap(uv[0], uv[1]);
-                std::swap(uv[3], uv[2]);
-            }
-            if (flip & tmx::TileLayer::FlipFlag::Vertical) {
-                std::swap(uv[0], uv[3]);
-                std::swap(uv[1], uv[2]);
-            }
-            if (flip & tmx::TileLayer::FlipFlag::Diagonal) {
-                std::swap(uv[1], uv[3]);
-            }
-
-            for (int v = 0; v < 4; ++v) {
-                quad[v].texCoords = uv[v];
-                va.append(quad[v]);
-            }
-        }
-
-        for (auto& [texPtr, vertices] : batches) {
-            layers_.push_back({texPtr, std::move(vertices)});
-        }
+    for (auto &[texPtr, vertices] : batches) {
+      layers_.push_back({texPtr, std::move(vertices)});
     }
+  }
 
-    return true;
+  return true;
 }
 
-void Map::draw(sf::RenderTarget& target) const {
-    for (const auto& layer : layers_) {
-        sf::RenderStates states;
-        states.texture = layer.texture;
-        target.draw(layer.vertices, states);
-    }
+void Map::draw(sf::RenderTarget &target) const {
+  for (const auto &layer : layers_) {
+    sf::RenderStates states;
+    states.texture = layer.texture;
+    target.draw(layer.vertices, states);
+  }
 }
-


### PR DESCRIPTION
## Summary
- render tiles using `sf::PrimitiveType::Triangles`
- document tile rendering change in CHANGELOG

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest --test-dir build/msvc -C Debug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ebeff9548327adebf21985057739