### PR TITLE
fix(build): link lumy-tests with dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Erro “Unsupported SFML component: system” (mudança para sintaxe do SFML 3).
 - Erro ao configurar por falta de `src/main.cpp`.
 - `src/main.cpp`: aplica `stack.applyPending()` logo após os eventos para garantir transições antes do fechamento da janela.
+- `CMakeLists.txt`: linka `lumy-tests` com TMXLITE e demais dependências.
 
 ### Docs
 - Adicionado `VISION.md`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,18 @@ add_executable(lumy-tests
   src/map.cpp
   src/texture_manager.cpp
 )
-target_link_libraries(lumy-tests PRIVATE GTest::gtest_main SFML::Graphics)
-target_include_directories(lumy-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(lumy-tests PRIVATE
+  GTest::gtest_main
+  SFML::Graphics SFML::Window SFML::Audio SFML::System
+  nlohmann_json::nlohmann_json
+  sol2::sol2
+  ${LUA_LIBRARIES}
+  PkgConfig::TMXLITE
+)
+target_include_directories(lumy-tests PRIVATE
+  ${CMAKE_SOURCE_DIR}/src
+  ${LUA_INCLUDE_DIR}
+)
 set_property(TARGET lumy-tests PROPERTY RUNTIME_OUTPUT_DIRECTORY "${OUT_DIR}")
 if(EXISTS "${EXAMPLES_DIR}")
   add_custom_command(TARGET lumy-tests POST_BUILD


### PR DESCRIPTION
## Summary
- link lumy-tests against tmxlite, Lua, sol2, and nlohmann-json
- document test target linkage in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ee9c99788327915248f2904066ef