### PR TITLE
refactor(map): replace Layer with TileLayer storing tile IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/map.cpp`: constrói `sf::Vector2u` de tamanho do tile explicitamente para evitar conversão implícita.
 - `src/main.cpp`/`src/boot_scene.*`: `TextureManager` global passado por referência ao `Map`.
 - `src/map.cpp`: substitui `sf::Quads` por `sf::PrimitiveType::Triangles` para desenhar tiles.
+- `src/map.hpp`/`src/map.cpp`: substitui `Layer` por `TileLayer` armazenando IDs de tiles e vértices.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -5,6 +5,7 @@
 #include <SFML/Graphics/VertexArray.hpp>
 
 #include <unordered_map>
+#include <cstdint>
 #include <vector>
 #include <string>
 
@@ -21,13 +22,14 @@ public:
     void draw(sf::RenderTarget& target) const;
 
 private:
-    struct Layer {
+    struct TileLayer {
         const sf::Texture* texture{};
+        std::vector<std::uint32_t> ids;
         sf::VertexArray vertices;
     };
 
     TextureManager& textures_;
     std::unordered_map<int, const sf::Texture*> tilesetTextures_;
-    std::vector<Layer> layers_;
+    std::vector<TileLayer> layers_;
 };
 


### PR DESCRIPTION
## Summary
- add TileLayer struct tracking tile IDs and vertices
- refactor map loading to build TileLayers
- document TileLayer refactor in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0767d00883279b576f8c9122c860