### PR TITLE
refactor(map): iterate tile ids for vertex batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`/`src/boot_scene.*`: `TextureManager` global passado por referência ao `Map`.
 - `src/map.cpp`: substitui `sf::Quads` por `sf::PrimitiveType::Triangles` para desenhar tiles.
 - `src/map.hpp`/`src/map.cpp`: substitui `Layer` por `TileLayer` armazenando IDs de tiles e vértices.
+- `src/map.cpp`: gera vértices percorrendo `TileLayer::ids`, move batches para `TileLayer::vertices` e remove `Layer` intermediário.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).


### PR DESCRIPTION
## Summary
- generate map vertices by iterating over TileLayer ids
- move vertex batches directly into TileLayer vertices and drop legacy Layer
- document map vertex batching changes

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest -C Debug` *(fails: No tests were found)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0adcda04832798e5a2f31122bba5