### PR TITLE
feat(runtime): add tile ID accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `DartConfiguration.tcl` com configuração básica para envios ao CDash.
 - `src/texture_manager.hpp`/`src/texture_manager.cpp`: cache simples de texturas.
 - Cache de texturas de tileset via `TextureManager`, evitando carregamentos duplicados.
+- `src/map.hpp`/`src/map.cpp`: métodos `getTileID` e `setTileID` com atualização do `VertexArray`.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -6,6 +6,7 @@
 
 #include <unordered_map>
 #include <cstdint>
+#include <cstddef>
 #include <vector>
 #include <string>
 
@@ -21,6 +22,9 @@ public:
     // Draws all loaded layers to the given render target.
     void draw(sf::RenderTarget& target) const;
 
+    std::uint32_t getTileID(std::size_t layer, unsigned x, unsigned y) const;
+    void setTileID(std::size_t layer, unsigned x, unsigned y, std::uint32_t id);
+
 private:
     struct TileLayer {
         const sf::Texture* texture{};
@@ -28,8 +32,19 @@ private:
         sf::VertexArray vertices;
     };
 
+    struct TilesetInfo {
+        int firstGid{};
+        sf::Vector2u tileSize;
+        unsigned columns{};
+        const sf::Texture* texture{};
+    };
+
     TextureManager& textures_;
     std::unordered_map<int, const sf::Texture*> tilesetTextures_;
     std::vector<TileLayer> layers_;
+    std::vector<TilesetInfo> tilesets_;
+    unsigned mapWidth_{};
+    unsigned mapHeight_{};
+    sf::Vector2u tileSize_{};
 };
 


### PR DESCRIPTION
## Summary
- allow querying and mutating tile IDs in Map
- keep vertices in sync when a tile changes

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*
- `ctest --test-dir build/msvc -C Debug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0bb510088327af6a88e5af100308