### PR TITLE
refactor(runtime): batch map draw per tileset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/map.cpp`: substitui `sf::Quads` por `sf::PrimitiveType::Triangles` para desenhar tiles.
 - `src/map.hpp`/`src/map.cpp`: substitui `Layer` por `TileLayer` armazenando IDs de tiles e vértices.
 - `src/map.cpp`: gera vértices percorrendo `TileLayer::ids`, move batches para `TileLayer::vertices` e remove `Layer` intermediário.
+- `src/map.cpp`: otimiza `Map::draw` para um draw por camada/tileset e comenta possíveis extensões de culling.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -221,9 +221,20 @@ void Map::setTileID(std::size_t layer, unsigned x, unsigned y, std::uint32_t id)
 }
 
 void Map::draw(sf::RenderTarget &target) const {
+  sf::RenderStates states;
+  const sf::Texture *currentTexture = nullptr;
+
   for (const auto &layer : layers_) {
-    sf::RenderStates states;
-    states.texture = layer.texture;
+    if (layer.vertices.getVertexCount() == 0)
+      continue;
+
+    if (layer.texture != currentTexture) {
+      currentTexture = layer.texture;
+      states.texture = currentTexture;
+    }
+
+    // Future extension: perform view-based culling here to skip drawing tiles
+    // outside the visible area, reducing unnecessary draw calls.
     target.draw(layer.vertices, states);
   }
 }


### PR DESCRIPTION
## Summary
- batch map draw calls per tileset layer and hint at culling
- log culling possibility in CHANGELOG

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion)*
- `cmake --build build/msvc --config Debug` *(fails: directory does not exist)*
- `./build/msvc/bin/Debug/hello-town` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0d1fa03c8327b99d964cbdef8681