### PR TITLE
feat(runtime): load TMX in MapScene via TextureManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/map.hpp`/`src/map.cpp`: substitui `Layer` por `TileLayer` armazenando IDs de tiles e vértices.
 - `src/map.cpp`: gera vértices percorrendo `TileLayer::ids`, move batches para `TileLayer::vertices` e remove `Layer` intermediário.
 - `src/map.cpp`: otimiza `Map::draw` para um draw por camada/tileset e comenta possíveis extensões de culling.
+- `src/map_scene.hpp`/`src/map_scene.cpp`: carrega TMX via `TextureManager` e posiciona o herói usando `spawn_x`/`spawn_y`.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/boot_scene.cpp
+++ b/src/boot_scene.cpp
@@ -1,5 +1,7 @@
 #include "boot_scene.hpp"
+#include "title_scene.hpp"
 #include <iostream>
+#include <memory>
 
 BootScene::BootScene(SceneStack& stack, TextureManager& textures)
     : stack_(stack), textures_(textures), map_(textures_) {
@@ -12,6 +14,7 @@ void BootScene::update(float) {
     if (!loaded_) {
         std::cout << "BootScene: loading core resources...\n";
         loaded_ = true;
+        stack_.switchScene(std::make_unique<TitleScene>(stack_, textures_));
     }
 }
 

--- a/src/map_scene.cpp
+++ b/src/map_scene.cpp
@@ -1,8 +1,24 @@
 #include "map_scene.hpp"
 #include <SFML/Window/Keyboard.hpp>
 #include <SFML/Window/Event.hpp>
+#include <tmxlite/Map.hpp>
 
-MapScene::MapScene(const sf::Vector2f& startPos) {
+MapScene::MapScene(TextureManager& textures, const std::string& tmxPath)
+    : textures_(textures), map_(textures_) {
+    map_.load(tmxPath);
+
+    sf::Vector2f startPos{0.f, 0.f};
+    tmx::Map tmxMap;
+    if (tmxMap.load(tmxPath)) {
+        for (const auto& prop : tmxMap.getProperties()) {
+            if (prop.getName() == "spawn_x") {
+                startPos.x = static_cast<float>(prop.getIntValue());
+            } else if (prop.getName() == "spawn_y") {
+                startPos.y = static_cast<float>(prop.getIntValue());
+            }
+        }
+    }
+
     hero_.setSize(sf::Vector2f{64.f, 64.f});
     hero_.setFillColor(sf::Color::White);
     hero_.setOrigin(sf::Vector2f{32.f, 32.f});
@@ -32,5 +48,6 @@ void MapScene::update(float deltaTime) {
 }
 
 void MapScene::draw(sf::RenderWindow& window) const {
+    map_.draw(window);
     window.draw(hero_);
 }

--- a/src/map_scene.hpp
+++ b/src/map_scene.hpp
@@ -1,17 +1,22 @@
 #pragma once
 
 #include "scene.hpp"
+#include "map.hpp"
+#include "texture_manager.hpp"
 #include <SFML/Graphics.hpp>
+#include <string>
 
 class MapScene : public Scene {
 public:
-    explicit MapScene(const sf::Vector2f& startPos);
+    explicit MapScene(TextureManager& textures, const std::string& tmxPath = "game/first.tmx");
 
     void handleEvent(const sf::Event& event) override;
     void update(float deltaTime) override;
     void draw(sf::RenderWindow& window) const override;
 
 private:
+    TextureManager& textures_;
+    Map map_;
     sf::RectangleShape hero_;
     float moveSpeed_ = 200.f;
 };

--- a/src/title_scene.cpp
+++ b/src/title_scene.cpp
@@ -3,8 +3,8 @@
 #include <memory>
 #include <stdexcept>
 
-TitleScene::TitleScene(SceneStack& stack)
-    : stack_(stack), startText_(font_, "Start", 32) {
+TitleScene::TitleScene(SceneStack& stack, TextureManager& textures)
+    : stack_(stack), textures_(textures), startText_(font_, "Start", 32) {
     if (!font_.openFromFile("game/font.ttf")) {
         throw std::runtime_error("failed to load font game/font.ttf");
     }
@@ -14,7 +14,7 @@ TitleScene::TitleScene(SceneStack& stack)
 void TitleScene::handleEvent(const sf::Event& event) {
     if (const auto* key = event.getIf<sf::Event::KeyPressed>();
         key && key->code == sf::Keyboard::Key::Enter) {
-        stack_.switchScene(std::make_unique<MapScene>(sf::Vector2f{320.f, 180.f}));
+        stack_.switchScene(std::make_unique<MapScene>(textures_));
     }
 }
 

--- a/src/title_scene.hpp
+++ b/src/title_scene.hpp
@@ -2,11 +2,12 @@
 
 #include "scene.hpp"
 #include "scene_stack.hpp"
+#include "texture_manager.hpp"
 #include <SFML/Graphics.hpp>
 
 class TitleScene : public Scene {
 public:
-    explicit TitleScene(SceneStack& stack);
+    explicit TitleScene(SceneStack& stack, TextureManager& textures);
 
     void handleEvent(const sf::Event& event) override;
     void update(float deltaTime) override;
@@ -14,6 +15,7 @@ public:
 
 private:
     SceneStack& stack_;
+    TextureManager& textures_;
     sf::Font font_;
     sf::Text startText_;
 };

--- a/tests/scene_flow.cpp
+++ b/tests/scene_flow.cpp
@@ -26,7 +26,7 @@ TEST(SceneFlow, BootTitleMap) {
     stack.applyPending();
     EXPECT_NE(dynamic_cast<MapScene*>(stack.current()), nullptr);
 
-    stack.switchScene(std::make_unique<TitleScene>(stack));
+    stack.switchScene(std::make_unique<TitleScene>(stack, textures));
     stack.applyPending();
     EXPECT_NE(dynamic_cast<TitleScene*>(stack.current()), nullptr);
 

--- a/tests/title_scene.cpp
+++ b/tests/title_scene.cpp
@@ -4,12 +4,14 @@
 
 #include "scene_stack.hpp"
 #include "title_scene.hpp"
+#include "texture_manager.hpp"
 
 TEST(TitleScene, MissingFontThrows) {
     auto old = std::filesystem::current_path();
     auto testsDir = std::filesystem::path{__FILE__}.parent_path();
     std::filesystem::current_path(testsDir);
     SceneStack stack;
-    EXPECT_THROW(TitleScene{stack}, std::runtime_error);
+    TextureManager textures;
+    EXPECT_THROW(TitleScene{stack, textures}, std::runtime_error);
     std::filesystem::current_path(old);
 }


### PR DESCRIPTION
## Summary
- load `first.tmx` into MapScene using TextureManager and spawn the hero from map properties
- pass TextureManager through TitleScene and BootScene to support map loading
- switch BootScene to TitleScene after loading core resources

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build directory missing)*
- `ctest --preset msvc-tests` *(fails: Invalid macro expansion in "msvc-vcpkg")*


------
https://chatgpt.com/codex/tasks/task_e_68aa13cfa4608327891a373a7a735d7b