### PR TITLE
feat: group TMX layers around hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/texture_manager.hpp`/`src/texture_manager.cpp`: cache simples de texturas.
 - Cache de texturas de tileset via `TextureManager`, evitando carregamentos duplicados.
 - `src/map.hpp`/`src/map.cpp`: métodos `getTileID` e `setTileID` com atualização do `VertexArray`.
+- `Map` (`src/map.hpp`/`src/map.cpp`): funções `drawLayer` e `drawRange` para desenhar camadas específicas.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).
@@ -70,6 +71,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/map.cpp`: gera vértices percorrendo `TileLayer::ids`, move batches para `TileLayer::vertices` e remove `Layer` intermediário.
 - `src/map.cpp`: otimiza `Map::draw` para um draw por camada/tileset e comenta possíveis extensões de culling.
 - `src/map_scene.hpp`/`src/map_scene.cpp`: carrega TMX via `TextureManager` e posiciona o herói usando `spawn_x`/`spawn_y`.
+- `src/map_scene.cpp`: desenho ordenado de camadas `ground_*` antes do herói e demais depois.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -22,6 +22,16 @@ public:
     // Draws all loaded layers to the given render target.
     void draw(sf::RenderTarget& target) const;
 
+    // Draws a single layer at the given index.
+    void drawLayer(std::size_t index, sf::RenderTarget& target) const;
+
+    // Draws layers in the range [first, last). If last exceeds the layer count,
+    // it is clamped to the end.
+    void drawRange(std::size_t first, std::size_t last, sf::RenderTarget& target) const;
+
+    std::size_t getLayerCount() const { return layers_.size(); }
+    const std::string& getLayerName(std::size_t index) const { return layers_[index].name; }
+
     std::uint32_t getTileID(std::size_t layer, unsigned x, unsigned y) const;
     void setTileID(std::size_t layer, unsigned x, unsigned y, std::uint32_t id);
 
@@ -30,6 +40,7 @@ private:
         const sf::Texture* texture{};
         std::vector<std::uint32_t> ids;
         sf::VertexArray vertices;
+        std::string name;
     };
 
     struct TilesetInfo {

--- a/src/map_scene.cpp
+++ b/src/map_scene.cpp
@@ -48,6 +48,21 @@ void MapScene::update(float deltaTime) {
 }
 
 void MapScene::draw(sf::RenderWindow& window) const {
-    map_.draw(window);
+    // Draw ground_* layers first
+    for (std::size_t i = 0; i < map_.getLayerCount(); ++i) {
+        const std::string& name = map_.getLayerName(i);
+        if (name.rfind("ground_", 0) == 0) {
+            map_.drawLayer(i, window);
+        }
+    }
+
     window.draw(hero_);
+
+    // Draw object_* and remaining layers
+    for (std::size_t i = 0; i < map_.getLayerCount(); ++i) {
+        const std::string& name = map_.getLayerName(i);
+        if (name.rfind("ground_", 0) != 0) {
+            map_.drawLayer(i, window);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expose Map::drawLayer and drawRange for selective TMX layer rendering
- draw ground_* layers before the hero and other layers after in MapScene

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1a4c5e908327ad0c33b74341539e