### PR TITLE
fix(runtime): cap FPS using SFML framerate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/map.cpp`: otimiza `Map::draw` para um draw por camada/tileset e comenta possíveis extensões de culling.
 - `src/map_scene.hpp`/`src/map_scene.cpp`: carrega TMX via `TextureManager` e posiciona o herói usando `spawn_x`/`spawn_y`.
 - `src/map_scene.cpp`: desenho ordenado de camadas `ground_*` antes do herói e demais depois.
+- `src/main.cpp`: usa `setFramerateLimit` para 60 FPS e remove `sf::sleep` manual.
 
 ### Fixed
 - Baseline do vcpkg: `"HEAD"` → SHA real (corrige “builtin-baseline inválido”).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,8 +53,9 @@ int main() {
     auto window = std::make_unique<sf::RenderWindow>(
         sf::VideoMode(sf::Vector2u{W, H}), "Lumy — hello-town");
 
-    // Limitador manual de FPS
-    const sf::Time targetFrameTime = sf::seconds(1.f / 60.f);
+    // Limita o framerate para ~60 FPS via SFML
+    window->setFramerateLimit(60);
+    // Relógio de frame e controle de deltaTime/FPS
     sf::Clock frameClock;
     std::size_t fpsFrameCount = 0;
     sf::Time fpsAccumulated = sf::Time::Zero;
@@ -112,12 +113,6 @@ int main() {
         }
         // 3. Exibir o frame
         window->display();
-
-        // Completar o tempo de frame restante
-        sf::Time workTime = frameClock.getElapsedTime();
-        if (workTime < targetFrameTime) {
-            sf::sleep(targetFrameTime - workTime);
-        }
     }
 
     window.reset();


### PR DESCRIPTION
## Summary
- use SFML's `setFramerateLimit` to cap the demo at ~60 FPS
- drop manual `sf::sleep` frame limiter
- document change in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build/msvc is not a directory)*
- `./build/msvc/bin/Debug/hello-town.exe` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1caf84b88327a56ddbae250ee2b8