### PR TITLE
test: wrap TitleScene initializer in EXPECT_THROW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: aplica `stack.applyPending()` logo após os eventos para garantir transições antes do fechamento da janela.
 - `CMakeLists.txt`: linka `lumy-tests` com TMXLITE e demais dependências.
 - `src/map.cpp`: inicializa IDs de tiles e trata camadas vazias.
+- `tests/title_scene.cpp`: envolve inicializador em parênteses no `EXPECT_THROW` para evitar erro de compilação.
 
 ### Docs
 - Adicionado `VISION.md`.

--- a/tests/title_scene.cpp
+++ b/tests/title_scene.cpp
@@ -12,6 +12,6 @@ TEST(TitleScene, MissingFontThrows) {
     std::filesystem::current_path(testsDir);
     SceneStack stack;
     TextureManager textures;
-    EXPECT_THROW(TitleScene{stack, textures}, std::runtime_error);
+    EXPECT_THROW((TitleScene{stack, textures}), std::runtime_error);
     std::filesystem::current_path(old);
 }


### PR DESCRIPTION
## Summary
- fix TitleScene test to wrap initializer in EXPECT_THROW and avoid MSVC parse issue
- document test fix in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2f6f4ed88327819cfdafe5cbcb9e