### PR TITLE
test: restore working directory via RAII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - Mapa de exemplo renomeado para `hello-town.tmx` e referências atualizadas.
 - `src/boot_scene.*`: carrega e desenha o mapa `game/hello-town.tmx` ao iniciar.
 - `tests/title_scene.cpp`: define diretório de trabalho relativo ao arquivo de teste.
+- `tests/title_scene.cpp`: restaura diretório de trabalho via RAII para segurança em exceções.
 - `src/map.hpp`/`src/map.cpp`: `Map` usa `TextureManager` e armazena ponteiros para texturas de tileset.
 - `src/map.cpp`: constrói `sf::Vector2u` de tamanho do tile explicitamente para evitar conversão implícita.
 - `src/main.cpp`/`src/boot_scene.*`: `TextureManager` global passado por referência ao `Map`.

--- a/tests/title_scene.cpp
+++ b/tests/title_scene.cpp
@@ -6,12 +6,24 @@
 #include "title_scene.hpp"
 #include "texture_manager.hpp"
 
+namespace {
+struct ScopedCurrentPath {
+    explicit ScopedCurrentPath(const std::filesystem::path& p)
+        : old_(std::filesystem::current_path()) {
+        std::filesystem::current_path(p);
+    }
+
+    ~ScopedCurrentPath() { std::filesystem::current_path(old_); }
+
+private:
+    std::filesystem::path old_;
+};
+} // namespace
+
 TEST(TitleScene, MissingFontThrows) {
-    auto old = std::filesystem::current_path();
     auto testsDir = std::filesystem::path{__FILE__}.parent_path();
-    std::filesystem::current_path(testsDir);
+    ScopedCurrentPath change{testsDir};
     SceneStack stack;
     TextureManager textures;
     EXPECT_THROW((TitleScene{stack, textures}), std::runtime_error);
-    std::filesystem::current_path(old);
 }


### PR DESCRIPTION
## Summary
- ensure TitleScene test restores working directory using RAII
- document test improvement in changelog

## Testing
- `cmake --preset msvc-vcpkg` *(fails: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(fails: /workspace/lumy/build/msvc is not a directory)*
- `ctest --test-dir build/msvc` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68aa30433e108327a71636548b775298