### PR TITLE
fix(map): normaliza caminho de tileset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `CMakeLists.txt`: linka `lumy-tests` com TMXLITE e demais dependências.
 - `src/map.cpp`: inicializa IDs de tiles e trata camadas vazias.
 - `tests/title_scene.cpp`: envolve inicializador em parênteses no `EXPECT_THROW` para evitar erro de compilação.
+- `src/map.cpp`: normaliza caminho das texturas de tileset evitando prefixo duplicado.
 
 ### Docs
 - Adicionado `VISION.md`.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -37,7 +37,11 @@ bool Map::load(const std::string &path) {
   std::vector<TilesetInfo> tilesets;
 
   for (const auto &ts : tmxMap.getTilesets()) {
-    auto texPath = base / ts.getImagePath();
+    std::filesystem::path texPath{ts.getImagePath()};
+    if (texPath.string().rfind(base.generic_string(), 0) != 0) {
+      texPath = base / texPath;
+    }
+    texPath = texPath.lexically_normal();
     const sf::Texture &tex = textures_.acquire(texPath);
     int first = static_cast<int>(ts.getFirstGID());
     tilesetTextures_.emplace(first, &tex);


### PR DESCRIPTION
## Summary
- fix prefixing logic for tileset texture paths in Map
- document tileset path normalization

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build -R basic_startup` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa500dbf788327a2b566a1d8d3bc8a