### PR TITLE
docs(test): document ctest usage without -T

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/main.cpp`: comentários explicando a sequência de renderização (limpar → desenhar → exibir).
 - `docs/scene_flow.md` e `README.md`: fluxo Boot → Title → Map e uso do `SceneStack`.
 - `docs/scene_flow.md` e `README.md`: documentada exceção ao falhar carregamento da fonte.
-- `contributing.md`: instruções para rodar testes com `ctest --output-on-failure -R <regex>` sem `-T test`.
+- `README.md` e `contributing.md`: instruções para rodar testes com `ctest -C Debug -R basic_startup`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ build/msvc/bin/Debug/hello-town.exe
 No VS Code, selecione os mesmos presets e depure o alvo `hello-town` com `F5`.
 
 
+## Testes
+
+Após compilar, execute os testes com:
+
+```sh
+ctest -C Debug -R basic_startup
+```
+
+
 ## Fluxo de cenas
 
 O exemplo `hello-town` usa `SceneStack` com as cenas Boot → Title → Map. `BootScene` carrega recursos e muda para `TitleScene`, que exibe "Start" (requer `game/font.ttf`; falha no carregamento lança exceção) e ao confirmar abre `MapScene` com um herói movido por W/A/S/D.

--- a/contributing.md
+++ b/contributing.md
@@ -34,10 +34,10 @@ Este guia explica como propor ideias, reportar bugs e enviar PRs de forma eficie
 Após compilar, execute os testes com:
 
 ```sh
-ctest --output-on-failure -R <regex>
+ctest -C Debug -R basic_startup
 ```
 
-Use `<regex>` para filtrar pelos nomes desejados.
+Use `-R` para filtrar pelos nomes desejados.
 A opção `-T test` não é mais necessária.
 
 ## Padrão de commits


### PR DESCRIPTION
## Summary
- document running tests with `ctest -C Debug -R basic_startup`
- update contributing instructions to drop `-T test`
- record docs update in changelog

## Testing
- `ctest -C Debug -R basic_startup`
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68aa515c966c83278d9bee1add68fc34