### PR TITLE
feat(runtime): posiciona jogador via objeto de spawn do TMX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 - `src/map.hpp`/`src/map.cpp`: métodos `getTileID` e `setTileID` com atualização do `VertexArray`.
 - `Map` (`src/map.hpp`/`src/map.cpp`): funções `drawLayer` e `drawRange` para desenhar camadas específicas.
 - `map_loader.py`: função `load_hello_map()` para parsear `hello.tmx` com tratamento de erros.
+- `src/map_scene.cpp`: posiciona o herói usando objeto `player`/`spawn` da camada de objetos do TMX com fallback.
 
 ### Changed
 - `CMakeLists.txt`: alvo **hello-town**; ajustes para **SFML 3** (componentes em maiúsculo e targets `SFML::`).


### PR DESCRIPTION
## Summary
- ler camada de objetos para obter `player`/`spawn` e posicionar o herói
- fallback para propriedades `spawn_x`/`spawn_y` quando o objeto não existe
- atualizar CHANGELOG

## Testing
- `cmake --preset msvc-vcpkg` *(falha: Invalid macro expansion in "msvc-vcpkg")*
- `cmake --build build/msvc --config Debug` *(falha: build/msvc is not a directory)*
- `ctest -C Debug` *(No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab37f5ab508327bf134131c435d66a