### PR TITLE
Fix viewport atlas loading from TilesetManager

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Segue SemVer: MAJOR.MINOR.PATCH (ex.: 0.2.1).
 ### Changed
 
 ### Fixed
+- Corrigido o carregamento do atlas de tiles no viewport para usar o tileset atual e evitar avisos de TileId inválido.
 
 ### Docs
 

--- a/editor/editor_frame.cpp
+++ b/editor/editor_frame.cpp
@@ -84,7 +84,11 @@ EditorFrame::EditorFrame()
     
     // Inicializar map manager
     m_mapManager = std::make_unique<MapManager>();
-    
+
+    if (m_mapTabsPanel) {
+        m_mapTabsPanel->SetMapManager(m_mapManager.get());
+    }
+
     // Conectar viewport com map manager (via MapTabsPanel)
     if (m_mapTabsPanel) {
         ViewportPanel* currentViewport = m_mapTabsPanel->GetCurrentViewport();
@@ -92,7 +96,18 @@ EditorFrame::EditorFrame()
             currentViewport->SetMapManager(m_mapManager.get());
         }
     }
-    
+
+    // Compartilhar TilesetManager com os viewports
+    TilesetPanel* tilesetPanel = m_leftSidePanel ? m_leftSidePanel->GetTilesetPanel() : nullptr;
+    TilesetManager* tilesetManager = tilesetPanel ? tilesetPanel->GetTilesetManager() : nullptr;
+    if (m_mapTabsPanel) {
+        m_mapTabsPanel->SetTilesetManager(tilesetManager);
+        ViewportPanel* currentViewport = m_mapTabsPanel->GetCurrentViewport();
+        if (currentViewport) {
+            currentViewport->SetTilesetManager(tilesetManager);
+        }
+    }
+
     // Carregar projeto padrão (diretório atual)
     wxString currentDir = wxGetCwd();
     LoadProject(currentDir);

--- a/editor/map_tabs_panel.cpp
+++ b/editor/map_tabs_panel.cpp
@@ -39,6 +39,8 @@ MapTabsPanel::MapTabsPanel(wxWindow* parent, wxWindowID id)
     , m_nextUntitledNumber(1)
     , m_contextMenu(nullptr)
     , m_contextTabIndex(-1)
+    , m_mapManager(nullptr)
+    , m_tilesetManager(nullptr)
 {
     CreateControls();
     CreateDefaultTab();
@@ -495,9 +497,17 @@ ViewportPanel* MapTabsPanel::CreateViewportForMap(std::shared_ptr<Map> map)
 {
     // Create viewport panel
     ViewportPanel* viewport = new ViewportPanel(m_notebook);
-    
+
+    if (m_mapManager) {
+        viewport->SetMapManager(m_mapManager);
+    }
+
+    if (m_tilesetManager) {
+        viewport->SetTilesetManager(m_tilesetManager);
+    }
+
     // Set the map
     viewport->SetCurrentMap(map.get());
-    
+
     return viewport;
 }

--- a/editor/map_tabs_panel.h
+++ b/editor/map_tabs_panel.h
@@ -14,6 +14,8 @@
 // Forward declarations
 class ViewportPanel;
 class Map;
+class MapManager;
+class TilesetManager;
 
 struct MapTabInfo
 {
@@ -37,6 +39,9 @@ public:
     bool CloseMap(int tabIndex);
     bool CloseAllMaps();
     void SetActiveMap(int tabIndex);
+
+    void SetMapManager(MapManager* mapManager) { m_mapManager = mapManager; }
+    void SetTilesetManager(TilesetManager* tilesetManager) { m_tilesetManager = tilesetManager; }
     
     // Current map access
     std::shared_ptr<Map> GetCurrentMap();
@@ -82,11 +87,14 @@ private:
     
     // UI Controls
     wxAuiNotebook* m_notebook;
-    
+
     // Data
     std::vector<MapTabInfo> m_mapTabs;
     int m_currentTabIndex;
     int m_nextUntitledNumber;
+
+    MapManager* m_mapManager;
+    TilesetManager* m_tilesetManager;
     
     // Context menu
     wxMenu* m_contextMenu;

--- a/editor/texture_atlas.h
+++ b/editor/texture_atlas.h
@@ -12,6 +12,9 @@
 #include <string>
 #include <memory>
 
+// Forward declarations
+struct TilesetInfo;
+
 /**
  * Coordenadas UV normalizadas para um tile específico
  */
@@ -76,13 +79,21 @@ public:
     
     /**
      * Carrega um tileset a partir de um arquivo de imagem
-     * 
+     *
      * @param filePath Caminho para o arquivo de imagem (PNG, BMP, etc.)
      * @param tileWidth Largura de cada tile em pixels
      * @param tileHeight Altura de cada tile em pixels
      * @return true se carregado com sucesso
      */
     bool LoadTileset(const wxString& filePath, int tileWidth = 32, int tileHeight = 32);
+
+    /**
+     * Carrega um tileset diretamente de uma estrutura TilesetInfo
+     *
+     * @param tilesetInfo Informações do tileset carregado pelo TilesetManager
+     * @return true se o atlas foi construído corretamente
+     */
+    bool LoadFromTilesetInfo(const TilesetInfo& tilesetInfo);
     
     /**
      * Descarrega o tileset e libera a textura OpenGL
@@ -163,6 +174,15 @@ private:
      * Método interno usado por GetTileUV
      */
     TileUV CalculateTileUV(int tileId) const;
+
+    /**
+     * Inicializa o atlas a partir de uma imagem já carregada em memória
+     */
+    bool LoadFromImage(const wxImage& image,
+                       int tileWidth,
+                       int tileHeight,
+                       const wxString& sourceName,
+                       int totalTilesOverride = -1);
 };
 
 /**

--- a/editor/viewport_panel.h
+++ b/editor/viewport_panel.h
@@ -19,6 +19,7 @@ class ShaderProgram;
 class MapRenderer;
 class TextureAtlas;
 class GridRenderer;
+struct TilesetInfo;
 
 class ViewportPanel : public wxPanel
 {
@@ -82,6 +83,7 @@ private:
         void DrawSelection();
         void DrawTilePreview(); // Preview do tile ao pintar
         void DrawMinimap(); // Mini-mapa no canto do viewport
+        bool LoadTilesetTexture(const TilesetInfo* tilesetInfo);
         
         wxGLContext* m_glContext;
         bool m_glInitialized;


### PR DESCRIPTION
## Summary
- teach the texture atlas to build itself from in-memory tileset data provided by the TilesetManager
- refresh the viewport atlas whenever the current tileset changes so OpenGL stops logging invalid TileId warnings
- share the TilesetManager with all map tabs so every viewport loads the same tileset atlas

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6909024211b0832790c7dfb1f87fead7